### PR TITLE
fix NaN gradients in Sphere

### DIFF
--- a/geoopt/manifolds/sphere.py
+++ b/geoopt/manifolds/sphere.py
@@ -154,7 +154,7 @@ class Sphere(Manifold):
         return torch.where(cond, u * dist / u.norm(dim=-1, keepdim=True), u)
 
     def dist(self, x, y, *, keepdim=False):
-        inner = self.inner(None, x, y, keepdim=keepdim).clamp(-1, 1)
+        inner = self.inner(None, x, y, keepdim=keepdim).clamp(-0.999, 0.999)
         return torch.acos(inner)
 
     egrad2rgrad = proju


### PR DESCRIPTION
I've been getting the error that AcosBackward gave NaN gradients. Slightly reducing the clamping fixes the error. One might use higher precisions. I just want to mention the problem with this pull request.