### PR TITLE
Clean up manifolds interface 

### DIFF
--- a/geoopt/manifolds/base.py
+++ b/geoopt/manifolds/base.py
@@ -301,11 +301,6 @@ class Manifold(torch.nn.Module, metaclass=abc.ABCMeta):
         -------
         tensor
             transported point
-
-        Notes
-        -----
-        By default, no error is raised if exponential map is not implemented. If so,
-        the best approximation to exponential map is applied instead.
         """
         raise NotImplementedError
 
@@ -332,8 +327,7 @@ class Manifold(torch.nn.Module, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    @abc.abstractmethod
-    def expmap_transp(self, x, u, v, *more):
+    def expmap_transp(self, x, u, v):
         """
         Perform an exponential map from point :math:`x` with
         given direction :math:`u`
@@ -346,23 +340,46 @@ class Manifold(torch.nn.Module, metaclass=abc.ABCMeta):
             tangent vector at point :math:`x`
         v : tensor
             tangent vector at point :math:`x` to be transported
-        more : tensors
-            other tangent vectors at point :math:`x` to be transported
 
         Returns
         -------
         tensor
             transported point
+        """
+        y = self.expmap(x, u)
+        v_transp = self.transp(x, y, v)
+        return (y, v_transp)
+
+    def retr_transp(self, x, u, v):
+        """
+        Perform a retraction + vector transport at once
+
+        Parameters
+        ----------
+        x : tensor
+            point on the manifold
+        v : tensor
+            tangent vector at point :math:`x` to be transported
+        u : tensor
+            tangent vector at point :math:`x` (required keyword only argument)
+        order : int
+            order of retraction approximation, by default uses the simplest.
+            Possible choices depend on a concrete manifold and -1 stays for exponential map
+
+        Returns
+        -------
+        tuple of tensors
+            transported point and vectors
 
         Notes
         -----
-        By default, no error is raised if exponential map is not implemented. If so,
-        the best approximation to exponential map is applied instead.
+        Sometimes this is a far more optimal way to preform retraction + vector transport
         """
-        raise NotImplementedError
+        y = self.retr(x, u)
+        v_transp = self.transp(x, y, v)
+        return (y, v_transp)
 
-    @abc.abstractmethod
-    def transp_follow_retr(self, x, u, v, *more):
+    def transp_follow_retr(self, x, u, v):
         """
         Perform vector transport from point :math:`x` for vector :math:`v` following a
         retraction map using vector :math:`u`
@@ -377,18 +394,16 @@ class Manifold(torch.nn.Module, metaclass=abc.ABCMeta):
             tangent vector at point :math:`x`
         v : tensor
             tangent vector at point :math:`x` to be transported
-        more : tensors
-            other tangent vectors at point :math:`x` to be transported
 
         Returns
         -------
-        tensor or tuple of tensors
-            transported tensor(s)
+        tensor
+            transported tensor
         """
-        raise NotImplementedError
+        y = self.retr(x, u)
+        return self.transp(x, y, v)
 
-    @abc.abstractmethod
-    def transp_follow_expmap(self, x, u, v, *more):
+    def transp_follow_expmap(self, x, u, v):
         """
         Perform vector transport from point :math:`x` for vector :math:`v` following a
         and exponential (best possible retraction) map using vector :math:`u`
@@ -403,17 +418,16 @@ class Manifold(torch.nn.Module, metaclass=abc.ABCMeta):
             tangent vector at point :math:`x`
         v : tensor
             tangent vector at point :math:`x` to be transported
-        more : tensors
-            other tangent vectors at point :math:`x` to be transported
 
         Returns
         -------
-        tensor or tuple of tensors
-            transported tensor(s)
+        tensor
+            transported tensor
         """
-        raise NotImplementedError
+        y = self.expmap(x, u)
+        return self.transp(x, y, v)
 
-    def transp(self, x, y, v, *more):
+    def transp(self, x, y, v):
         """
         Perform vector transport from point :math:`x` for vector :math:`v` following a
         and exponential (best possible retraction) map using vector :math:`u`
@@ -428,9 +442,6 @@ class Manifold(torch.nn.Module, metaclass=abc.ABCMeta):
             target point on the manifold
         v : tensor
             tangent vector at point :math:`x`
-
-        more : tensors
-           other tangent vectors at point :math:`x` to be transported
 
         Returns
         -------
@@ -534,36 +545,6 @@ class Manifold(torch.nn.Module, metaclass=abc.ABCMeta):
         -------
         tensor
             projected point
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def retr_transp(self, x, u, v, *more):
-        """
-        Perform a retraction + vector transport at once
-
-        Parameters
-        ----------
-        x : tensor
-            point on the manifold
-        v : tensor
-            tangent vector at point :math:`x` to be transported
-        more : tensors
-            other tangent vector at point :math:`x` to be transported
-        u : tensor
-            tangent vector at point :math:`x` (required keyword only argument)
-        order : int
-            order of retraction approximation, by default uses the simplest.
-            Possible choices depend on a concrete manifold and -1 stays for exponential map
-
-        Returns
-        -------
-        tuple of tensors
-            transported point and vectors
-
-        Notes
-        -----
-        Sometimes this is a far more optimal way to preform retraction + vector transport
         """
         raise NotImplementedError
 

--- a/geoopt/manifolds/euclidean.py
+++ b/geoopt/manifolds/euclidean.py
@@ -37,21 +37,11 @@ class R(Manifold):
     def projx(self, x):
         return x
 
-    def transp_follow_expmap(self, x, u, v, *more):
-        return strip_tuple((v, *more))
-
-    transp_follow_retr = transp_follow_expmap
-
     def logmap(self, x, y):
         return y - x
 
     def dist(self, x, y, *, keepdim=False):
         return (x - y).abs()
-
-    def expmap_transp(self, x, u, v, *more):
-        return (x + u, v, *more)
-
-    retr_transp = expmap_transp
 
     def egrad2rgrad(self, x, u):
         return u
@@ -59,8 +49,8 @@ class R(Manifold):
     def expmap(self, x, u):
         return x + u
 
-    def transp(self, x, y, v, *more):
-        return strip_tuple((v, *more))
+    def transp(self, x, y, v):
+        return v
 
     def random_normal(self, *size, mean=0.0, std=1.0, device=None, dtype=None):
         """

--- a/geoopt/manifolds/poincare/__init__.py
+++ b/geoopt/manifolds/poincare/__init__.py
@@ -23,7 +23,7 @@ _poincare_ball_doc = r"""
 # noinspection PyMethodOverriding
 class PoincareBall(Manifold):
     __doc__ = r"""{}
- 
+
     See Also
     --------
     :class:`PoincareBallExact`
@@ -86,32 +86,26 @@ class PoincareBall(Manifold):
     def logmap(self, x, y, *, dim=-1):
         return math.logmap(x, y, c=self.c, dim=dim)
 
-    def transp(self, x, y, v, *more, dim=-1):
-        if not more:
-            return math.parallel_transport(x, y, v, c=self.c, dim=dim)
-        else:
-            return tuple(
-                math.parallel_transport(x, y, vec, c=self.c, dim=dim)
-                for vec in (v, *more)
-            )
+    def transp(self, x, y, v, dim=-1):
+        return math.parallel_transport(x, y, v, c=self.c, dim=dim)
 
-    def transp_follow_retr(self, x, u, v, *more, dim=-1):
+    def transp_follow_retr(self, x, u, v, dim=-1):
         y = self.retr(x, u, dim=dim)
-        return self.transp(x, y, v, *more, dim=dim)
+        return self.transp(x, y, v, dim=dim)
 
-    def transp_follow_expmap(self, x, u, v, *more, dim=-1, project=True):
+    def transp_follow_expmap(self, x, u, v, dim=-1, project=True):
         y = self.expmap(x, u, dim=dim, project=project)
-        return self.transp(x, y, v, *more, dim=dim)
+        return self.transp(x, y, v, dim=dim)
 
-    def expmap_transp(self, x, u, v, *more, dim=-1, project=True):
+    def expmap_transp(self, x, u, v, dim=-1, project=True):
         y = self.expmap(x, u, dim=dim, project=project)
-        vs = self.transp(x, y, v, *more, dim=dim)
-        return (y,) + make_tuple(vs)
+        v_transp = self.transp(x, y, v, dim=dim)
+        return (y, v_transp)
 
-    def retr_transp(self, x, u, v, *more, dim=-1):
+    def retr_transp(self, x, u, v, dim=-1):
         y = self.retr(x, u, dim=dim)
-        vs = self.transp(x, y, v, *more, dim=dim)
-        return (y,) + make_tuple(vs)
+        v_transp = self.transp(x, y, v, dim=dim)
+        return (y, v_transp)
 
     def mobius_add(self, x, y, *, dim=-1, project=True):
         res = math.mobius_add(x, y, c=self.c, dim=dim)
@@ -248,7 +242,7 @@ class PoincareBallExact(PoincareBall):
     __doc__ = r"""{}
 
     The implementation of retraction is an exact exponential map, this retraction will be used in optimization
-    
+
     See Also
     --------
     :class:`PoincareBall`

--- a/geoopt/manifolds/sphere.py
+++ b/geoopt/manifolds/sphere.py
@@ -2,7 +2,7 @@ import torch
 
 from .base import Manifold
 from ..tensor import ManifoldTensor
-from ..utils import strip_tuple, make_tuple, size2shape
+from ..utils import size2shape
 import geoopt.linalg.batch_linalg
 
 __all__ = ["Sphere", "SphereExact"]
@@ -30,7 +30,7 @@ _sphere_doc = r"""
 
 class Sphere(Manifold):
     __doc__ = r"""{}
-    
+
     See Also
     --------
     :class:`SphereExact`
@@ -129,27 +129,8 @@ class Sphere(Manifold):
     def retr(self, x, u):
         return self.projx(x + u)
 
-    def transp_follow_retr(self, x, u, v, *more):
-        y = self.retr(x, u)
-        return self.transp(x, y, v, *more)
-
-    def transp(self, x, y, v, *more):
-        result = tuple(self.proju(y, _v) for _v in (v,) + more)
-        return strip_tuple(result)
-
-    def transp_follow_expmap(self, x, u, v, *more):
-        y = self.expmap(x, u)
-        return self.transp(x, y, v, *more)
-
-    def expmap_transp(self, x, u, v, *more):
-        y = self.expmap(x, u)
-        vs = self.transp(x, y, v, *more)
-        return (y,) + make_tuple(vs)
-
-    def retr_transp(self, x, u, v, *more):
-        y = self.retr(x, u)
-        vs = self.transp(x, y, v, *more)
-        return (y,) + make_tuple(vs)
+    def transp(self, x, y, v):
+        return self.proju(y, v)
 
     def logmap(self, x, y):
         u = self.proju(x, y - x)
@@ -230,7 +211,7 @@ class SphereExact(Sphere):
     See Also
     --------
     :class:`Sphere`
-    
+
     Notes
     -----
     The implementation of retraction is an exact exponential map, this retraction will be used in optimization


### PR DESCRIPTION
- [ ] Provide default implementations for methods that are included for efficiency reasons in certain manifolds when performing combined retr/expmap and parallel transport operations.
- [ ] Remove the `*more` params
- [ ] Revisit the documentation