### PR TITLE
fixed second momentum in radam (?)

### DIFF
--- a/geoopt/optim/radam.py
+++ b/geoopt/optim/radam.py
@@ -88,7 +88,7 @@ class RiemannianAdam(OptimMixin, torch.optim.Adam):
                     grad = manifold.egrad2rgrad(point, grad)
                     exp_avg.mul_(betas[0]).add_(1 - betas[0], grad)
                     exp_avg_sq.mul_(betas[1]).add_(
-                        1 - betas[1], manifold.inner(point, grad, keepdim=True)
+                        1 - betas[1], manifold.inner(grad, grad, keepdim=True)
                     )
                     if amsgrad:
                         max_exp_avg_sq = state["max_exp_avg_sq"]


### PR DESCRIPTION
According to the original paper, the second momentum update-term is ||g^i||^2, where ||g^i||^2=p(g^i, g^i). I think what's currently happening is p(w^i, g^i) where w is the weight in iteration i.

I am not sure, but I haven't found any indication how p(w^i, g^i) would make sense, especially in the euclidian space.