### PR TITLE
implementation of SPD manifolds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,12 +19,12 @@
 import sys
 import os
 
-import geoopt
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
+
+import geoopt
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/manifolds.rst
+++ b/docs/manifolds.rst
@@ -7,6 +7,6 @@ Manifolds
 All manifolds share same API. Some manifols may have several implementations of retraction operation, every implementation has a corresponding class.
 
 .. automodule:: geoopt.manifolds
-    :members: Euclidean, Stiefel, CanonicalStiefel, EuclideanStiefel, EuclideanStiefelExact, Sphere, SphereExact, Stereographic, StereographicExact, PoincareBall, PoincareBallExact, SphereProjection, SphereProjectionExact, Scaled, ProductManifold, Lorentz
+    :members: Euclidean, Stiefel, CanonicalStiefel, EuclideanStiefel, EuclideanStiefelExact, Sphere, SphereExact, Stereographic, StereographicExact, PoincareBall, PoincareBallExact, SphereProjection, SphereProjectionExact, Scaled, ProductManifold, Lorentz, SymmetricPositiveDefinite
 
 

--- a/geoopt/__init__.py
+++ b/geoopt/__init__.py
@@ -26,6 +26,7 @@ from .manifolds import (
     Scaled,
     Lorentz,
     BirkhoffPolytope,
+    SymmetricPositiveDefinite,
 )
 
 __version__ = "0.3.1"

--- a/geoopt/linalg/batch_linalg.py
+++ b/geoopt/linalg/batch_linalg.py
@@ -1,8 +1,22 @@
-from typing import List
 import torch.jit
 from . import _expm
 
-__all__ = ["svd", "qr", "sym", "extract_diag", "matrix_rank", "expm", "block_matrix"]
+__all__ = [
+    "svd",
+    "qr",
+    "sym",
+    "extract_diag",
+    "matrix_rank",
+    "expm",
+    "block_matrix",
+    "sym_funcm",
+    "sym_expm",
+    "sym_logm",
+    "sym_sqrtm",
+    "sym_invm",
+    "sym_inv_sqrtm1",
+    "sym_inv_sqrtm2",
+]
 
 
 @torch.jit.script
@@ -75,6 +89,134 @@ def block_matrix(blocks: List[List[torch.Tensor]], dim0: int = -2, dim1: int = -
     for mats in blocks:
         hblocks.append(torch.cat(mats, dim=dim1))
     return torch.cat(hblocks, dim=dim0)
+
+
+def sym_funcm(
+    x: torch.Tensor, func: Callable[[torch.Tensor], torch.Tensor]
+) -> torch.Tensor:
+    """Apply function to symmetric matrix.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        symmetric matrix
+    func : Callable[[torch.Tensor], torch.Tensor]
+        function to apply
+
+    Returns
+    -------
+    torch.Tensor
+        symmetric matrix with function applied to
+    """
+    e, v = torch.symeig(x, eigenvectors=True)
+    return v @ torch.diag_embed(func(e)) @ v.transpose(-1, -2)
+
+
+def sym_expm(x: torch.Tensor, using_native=False) -> torch.Tensor:
+    r"""Symmetric matrix exponent.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        symmetric matrix
+    using_native : bool, optional
+        if using native matrix exponent `torch.matrix_exp`, by default False
+
+    Returns
+    -------
+    torch.Tensor
+        :math:`\exp(x)`
+    """
+    if using_native:
+        return torch.matrix_exp(x)
+    else:
+        return sym_funcm(x, torch.exp)
+
+
+def sym_logm(x: torch.Tensor) -> torch.Tensor:
+    r"""Symmetric matrix logarithm.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        symmetric matrix
+
+    Returns
+    -------
+    torch.Tensor
+        :math:`\log(x)`
+    """
+    return sym_funcm(x, torch.log)
+
+
+def sym_sqrtm(x: torch.Tensor) -> torch.Tensor:
+    """Symmetric matrix square root .
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        symmetric matrix
+
+    Returns
+    -------
+    torch.Tensor
+        :math:`x^{1/2}`
+    """
+    return sym_funcm(x, torch.sqrt)
+
+
+def sym_invm(x: torch.Tensor) -> torch.Tensor:
+    """Symmetric matrix inverse.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        symmetric matrix
+
+    Returns
+    -------
+    torch.Tensor
+        :math:`x^{-1}`
+    """
+    return sym_funcm(x, torch.reciprocal)
+
+
+def sym_inv_sqrtm1(x: torch.Tensor) -> torch.Tensor:
+    """Symmetric matrix inverse square root.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        symmetric matrix
+
+    Returns
+    -------
+    torch.Tensor
+        :math:`x^{-1/2}`
+    """
+    return sym_funcm(x, lambda tensor: torch.reciprocal(torch.sqrt(tensor)))
+
+
+def sym_inv_sqrtm2(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Symmetric matrix inverse square root, with square root return also.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        symmetric matrix
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        :math:`x^{-1/2}`, :math:`x^{1/2}`
+    """
+    e, v = torch.symeig(x, eigenvectors=True)
+    sqrt_e = torch.sqrt(e)
+    inv_sqrt_e = 1 / sqrt_e
+    return (
+        v @ torch.diag_embed(inv_sqrt_e) @ v.transpose(-1, -2),
+        v @ torch.diag_embed(sqrt_e) @ v.transpose(-1, -2),
+    )
 
 
 # left here for convenience

--- a/geoopt/linalg/batch_linalg.py
+++ b/geoopt/linalg/batch_linalg.py
@@ -1,3 +1,5 @@
+from typing import List, Callable, Tuple
+import torch
 import torch.jit
 from . import _expm
 
@@ -89,6 +91,23 @@ def block_matrix(blocks: List[List[torch.Tensor]], dim0: int = -2, dim1: int = -
     for mats in blocks:
         hblocks.append(torch.cat(mats, dim=dim1))
     return torch.cat(hblocks, dim=dim0)
+
+
+@torch.jit.script
+def trace(x: torch.Tensor) -> torch.Tensor:
+    r"""self-implemented matrix trace, since `torch.trace` only support 2-d input.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        input matrix
+
+    Returns
+    -------
+    torch.Tensor
+        :math:`\operationname{Tr}(x)`
+    """
+    return torch.diagonal(x, dim1=-2, dim2=-1).sum(-1)
 
 
 def sym_funcm(

--- a/geoopt/linalg/batch_linalg.py
+++ b/geoopt/linalg/batch_linalg.py
@@ -105,7 +105,7 @@ def trace(x: torch.Tensor) -> torch.Tensor:
     Returns
     -------
     torch.Tensor
-        :math:`\operationname{Tr}(x)`
+        :math:`\operatorname{Tr}(x)`
     """
     return torch.diagonal(x, dim1=-2, dim2=-1).sum(-1)
 
@@ -231,7 +231,7 @@ def sym_inv_sqrtm2(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     e, v = torch.symeig(x, eigenvectors=True)
     sqrt_e = torch.sqrt(e)
-    inv_sqrt_e = 1 / sqrt_e
+    inv_sqrt_e = torch.reciprocal(sqrt_e)
     return (
         v @ torch.diag_embed(inv_sqrt_e) @ v.transpose(-1, -2),
         v @ torch.diag_embed(sqrt_e) @ v.transpose(-1, -2),

--- a/geoopt/manifolds/__init__.py
+++ b/geoopt/manifolds/__init__.py
@@ -3,6 +3,7 @@ from .euclidean import Euclidean
 from .stiefel import Stiefel, EuclideanStiefel, CanonicalStiefel, EuclideanStiefelExact
 from .sphere import Sphere, SphereExact
 from .birkhoff_polytope import BirkhoffPolytope
+from .symmetric_positive_definite import SymmetricPositiveDefinite
 from .stereographic import (
     PoincareBall,
     PoincareBallExact,

--- a/geoopt/manifolds/symmetric_positive_definite.py
+++ b/geoopt/manifolds/symmetric_positive_definite.py
@@ -1,7 +1,8 @@
 from functools import partial
-from typing import Callable, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 import torch
 from .base import Manifold
+from ..linalg import batch_linalg
 
 __all__ = ["SymmetricPositiveDefinite"]
 
@@ -45,146 +46,6 @@ class SymmetricPositiveDefinite(Manifold):
         self.ndim = ndim
         self.defaulf_metric = defaulf_metric
 
-    def _funcm(
-        self, x: torch.Tensor, func: Callable[[torch.Tensor], torch.Tensor]
-    ) -> torch.Tensor:
-        """Apply function to symmetric matrix.
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            symmetric matrix
-        func : Callable[[torch.Tensor], torch.Tensor]
-            function to apply
-
-        Returns
-        -------
-        torch.Tensor
-            symmetric matrix with function applied to
-        """
-        e, v = torch.symeig(x, eigenvectors=True)
-        return v @ torch.diag_embed(func(e)) @ v.transpose(-1, -2)
-
-    def _expm(self, x: torch.Tensor, using_native=False) -> torch.Tensor:
-        """Symmetric matrix exponent.
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            symmetric matrix
-        using_native : bool, optional
-            if using native matrix exponent `torch.matrix_exp`, by default False
-
-        Returns
-        -------
-        torch.Tensor
-            :math:`\exp(x)`
-        """
-        if using_native:
-            return torch.matrix_exp(x)
-        else:
-            return self._funcm(x, torch.exp)
-
-    def _logm(self, x: torch.Tensor) -> torch.Tensor:
-        r"""Symmetric matrix logarithm.
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            symmetric matrix
-
-        Returns
-        -------
-        torch.Tensor
-            :math:`\log(x)`
-        """
-        return self._funcm(x, torch.log)
-
-    def _sqrtm(self, x: torch.Tensor) -> torch.Tensor:
-        """Symmetric matrix square root .
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            symmetric matrix
-
-        Returns
-        -------
-        torch.Tensor
-            :math:`x^{1/2}`
-        """
-        return self._funcm(x, torch.sqrt)
-
-    def _invm(self, x: torch.Tensor) -> torch.Tensor:
-        """Symmetric matrix inverse.
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            symmetric matrix
-
-        Returns
-        -------
-        torch.Tensor
-            :math:`x^{-1}`
-        """
-        return self._funcm(x, torch.reciprocal)
-
-    def _inv_sqrtm1(self, x: torch.Tensor) -> torch.Tensor:
-        """Symmetric matrix inverse square root.
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            symmetric matrix
-
-        Returns
-        -------
-        torch.Tensor
-            :math:`x^{-1/2}`
-        """
-        return self._funcm(x, lambda tensor: torch.reciprocal(torch.sqrt(tensor)))
-
-    def _inv_sqrtm2(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Symmetric matrix inverse square root, with square root return also.
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            symmetric matrix
-
-        Returns
-        -------
-        Tuple[torch.Tensor, torch.Tensor]
-            :math:`x^{-1/2}`, :math:`x^{1/2}`
-        """
-        e, v = torch.symeig(x, eigenvectors=True)
-        sqrt_e = torch.sqrt(e)
-        inv_sqrt_e = 1 / sqrt_e
-        return (
-            v @ torch.diag_embed(inv_sqrt_e) @ v.transpose(-1, -2),
-            v @ torch.diag_embed(sqrt_e) @ v.transpose(-1, -2),
-        )
-
-    def _sym(self, x: torch.Tensor) -> torch.Tensor:
-        r"""Make matrix symmetric.
-
-        .. math::
-
-            \frac{A + A^T}{2}
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            matrix to symmetrize
-
-        Returns
-        -------
-        torch.Tensor
-            symmetric matrix
-        """
-        return (x + x.transpose(-1, -2)) / 2
-
     _dist_doc = """
         Parameters
         ----------
@@ -214,9 +75,11 @@ class SymmetricPositiveDefinite(Manifold):
         """.format(
             self._dist_doc
         )
-        inv_sqrt_x = self._inv_sqrtm1(x)
+        inv_sqrt_x = batch_linalg.sym_inv_sqrtm1(x)
         return 0.5 * torch.norm(
-            self._logm(inv_sqrt_x @ y @ inv_sqrt_x), dim=[-1, -2], keepdim=keepdim
+            batch_linalg.sym_logm(inv_sqrt_x @ y @ inv_sqrt_x),
+            dim=[-1, -2],
+            keepdim=keepdim,
         )
 
     def _stein_metric(
@@ -253,7 +116,11 @@ class SymmetricPositiveDefinite(Manifold):
         """.format(
             self._dist_doc
         )
-        return torch.norm(self._logm(x) - self._logm(y), dim=[-1, -2], keepdim=keepdim)
+        return torch.norm(
+            batch_linalg.sym_logm(x) - batch_linalg.sym_logm(y),
+            dim=[-1, -2],
+            keepdim=keepdim,
+        )
 
     def _check_point_on_manifold(
         self, x: torch.Tensor, *, atol=1e-5, rtol=1e-5
@@ -276,11 +143,11 @@ class SymmetricPositiveDefinite(Manifold):
         return True, None
 
     def projx(self, x: torch.Tensor) -> torch.Tensor:
-        symx = self._sym(x)
-        return self._funcm(symx, partial(torch.clamp, min=EPS[x.dtype]))
+        symx = batch_linalg.sym(x)
+        return batch_linalg.sym_funcm(symx, partial(torch.clamp, min=EPS[x.dtype]))
 
     def proju(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
-        return self._sym(u)
+        return batch_linalg.sym(u)
 
     def egrad2rgrad(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
         return x @ self.proju(x, u) @ x.transpose(-1, -2)
@@ -366,20 +233,20 @@ class SymmetricPositiveDefinite(Manifold):
             v = u
         if keepdim:
             raise ValueError("`torch.trace` doesn't support keepdim.")
-        inv_x = self._invm(x)
+        inv_x = batch_linalg.sym_invm(x)
         return torch.trace(inv_x @ u @ inv_x @ v)
 
     def retr(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
-        inv_x = self._invm(x)
-        return self._sym(x + u + u @ inv_x @ u / 2)
+        inv_x = batch_linalg.sym_invm(x)
+        return batch_linalg.sym(x + u + u @ inv_x @ u / 2)
 
     def expmap(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
-        inv_sqrt_x, sqrt_x = self._inv_sqrtm2(x)
-        return sqrt_x @ self._expm(inv_sqrt_x @ u @ inv_sqrt_x) @ sqrt_x
+        inv_sqrt_x, sqrt_x = batch_linalg.sym_sqrtm2(x)
+        return sqrt_x @ batch_linalg.sym_expm(inv_sqrt_x @ u @ inv_sqrt_x) @ sqrt_x
 
     def logmap(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
-        inv_sqrt_x, sqrt_x = self._inv_sqrtm2(x)
-        return sqrt_x @ self._logm(inv_sqrt_x @ u @ inv_sqrt_x) @ sqrt_x
+        inv_sqrt_x, sqrt_x = batch_linalg.sym_inv_sqrtm2(x)
+        return sqrt_x @ batch_linalg.sym_logm(inv_sqrt_x @ u @ inv_sqrt_x) @ sqrt_x
 
     def extra_repr(self) -> str:
         return "ndim={}".format(self.ndim)

--- a/geoopt/manifolds/symmetric_positive_definite.py
+++ b/geoopt/manifolds/symmetric_positive_definite.py
@@ -40,8 +40,9 @@ class SymmetricPositiveDefinite(Manifold):
     reversible = False
     defaulf_metric: str = "AIM"
 
-    def __init__(self, ndim=2, defaulf_metric: str = defaulf_metric):
+    def __init__(self, dim=2, ndim=2, defaulf_metric: str = defaulf_metric):
         super().__init__()
+        self.dim = dim
         self.ndim = ndim
         self.defaulf_metric = defaulf_metric
 
@@ -239,7 +240,7 @@ class SymmetricPositiveDefinite(Manifold):
 
     def retr(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
         inv_x = batch_linalg.sym_invm(x)
-        return x + u + 0.5 * u @ inv_x @ u
+        return batch_linalg.sym(x + u + 0.5 * u @ inv_x @ u)
 
     def expmap(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
         inv_sqrt_x, sqrt_x = batch_linalg.sym_inv_sqrtm2(x)
@@ -250,7 +251,7 @@ class SymmetricPositiveDefinite(Manifold):
         return sqrt_x @ batch_linalg.sym_logm(inv_sqrt_x @ u @ inv_sqrt_x) @ sqrt_x
 
     def extra_repr(self) -> str:
-        return "ndim={}".format(self.ndim)
+        return "ndim={}&dim={}".format(self.ndim, self.dim)
 
     def transp(self, x: torch.Tensor, y: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
         inv_sqrt_x, sqrt_x = batch_linalg.sym_inv_sqrtm2(x)
@@ -264,3 +265,9 @@ class SymmetricPositiveDefinite(Manifold):
             @ exp_x_y
             @ sqrt_x
         )
+
+    def random(self, *size, dtype=None, device=None, **kwargs) -> torch.Tensor:
+        tens = 0.5 * torch.randn(*size, dtype=dtype, device=device)
+        tens = batch_linalg.sym(tens)
+        tens = batch_linalg.sym_funcm(tens, torch.exp)
+        return tens

--- a/geoopt/manifolds/symmetric_positive_definite.py
+++ b/geoopt/manifolds/symmetric_positive_definite.py
@@ -1,0 +1,213 @@
+from functools import partial
+from typing import Callable, Literal, Optional, Tuple, Union, get_args
+import torch
+from .base import Manifold
+
+__all__ = ["SymmetricPositiveDefinite"]
+
+
+EPS = {torch.float32: 1e-4, torch.float64: 1e-7}
+
+
+class SymmetricPositiveDefinite(Manifold):
+    r"""
+    Manifold of symmetric positive definite matrices.
+
+    .. math::
+
+        A = A^T\\
+        \langle x, A x \rangle > 0 \quad , \forall x \in \mathrm{R}^{n}, x \neq 0 \\
+        A \in \mathrm{R}^{n\times m}
+
+
+    The tangent space of the manifold contains all symmetric matrices.
+    
+    Reference implementations:
+    - https://github.com/pymanopt/pymanopt/blob/master/pymanopt/manifolds/psd.py
+    - https://github.com/dalab/matrix-manifolds/blob/master/graphembed/graphembed/manifolds/spd.py
+
+    Parameters
+    ----------
+    ndim : int
+        number of trailing dimensions treated as matrix dimensions. All the operations acting on cuch
+        as inner products, etc will respect the :attr:`ndim`.
+    """
+
+    __scaling__ = Manifold.__scaling__.copy()
+    name = "SymmetricPositiveDefinite"
+    ndim = 0
+    reversible = True
+    _metric_literal = Literal["AIM", "SM", "LEM"]
+    defaulf_metric: _metric_literal = "AIM"
+
+    def __init__(self, ndim=2, defaulf_metric: _metric_literal = defaulf_metric):
+        super().__init__()
+        self.ndim = ndim
+        self.defaulf_metric = defaulf_metric
+
+    def _t(self, x: torch.Tensor) -> torch.Tensor:
+        return x.transpose(-1, -2)
+
+    def _funcm(
+        self, x: torch.Tensor, func: Callable[[torch.Tensor], torch.Tensor]
+    ) -> torch.Tensor:
+        e, v = torch.symeig(x, eigenvectors=True)
+        return v @ torch.diag_embed(func(e)) @ v.transpose(-1, -2)
+
+    def _expm(self, x: torch.Tensor, using_native=False) -> torch.Tensor:
+        if using_native:
+            return torch.matrix_exp(x)
+        else:
+            return self._funcm(x, torch.exp)
+
+    def _logm(self, x: torch.Tensor) -> torch.Tensor:
+        return self._funcm(x, torch.log)
+
+    def _sqrtm(self, x: torch.Tensor) -> torch.Tensor:
+        return self._funcm(x, torch.sqrt)
+
+    def _invm(self, x: torch.Tensor) -> torch.Tensor:
+        return self._funcm(x, torch.reciprocal)
+
+    def _inv_sqrtm1(self, x: torch.Tensor) -> torch.Tensor:
+        return self._funcm(x, lambda tensor: torch.reciprocal(torch.sqrt(tensor)))
+
+    def _inv_sqrtm2(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        e, v = torch.symeig(x, eigenvectors=True)
+        sqrt_e = torch.sqrt(e)
+        inv_sqrt_e = 1 / sqrt_e
+        return (
+            v @ torch.diag_embed(inv_sqrt_e) @ v.transpose(-1, -2),
+            v @ torch.diag_embed(sqrt_e) @ v.transpose(-1, -2),
+        )
+
+    def _affine_invariant_metric(
+        self, x: torch.Tensor, y: torch.Tensor, keepdim=False
+    ) -> torch.Tensor:
+        # Affine Invariant Metric
+        # Ref:
+        # Pennec, Xavier, Pierre Fillard, and Nicholas Ayache. "A Riemannian framework for tensor computing." International Journal of computer vision 66.1 (2006): 41-66.
+        inv_sqrt_x = self._inv_sqrtm1(x)
+        return 0.5 * torch.norm(
+            self._logm(inv_sqrt_x @ y @ inv_sqrt_x), dim=[-1, -2], keepdim=keepdim
+        )
+
+    def _affine_invariant_inner(
+        self,
+        x: torch.Tensor,
+        u: torch.Tensor,
+        v: torch.Tensor = None,
+        keepdim=False,
+    ) -> torch.Tensor:
+        assert not keepdim, "`torch.trace` doesn't support keepdim."
+        inv_x = self._invm(x)
+        return torch.trace(inv_x @ u @ inv_x @ v)
+
+    def _stein_metric(
+        self, x: torch.Tensor, y: torch.Tensor, keepdim=False
+    ) -> torch.Tensor:
+        # Stein Metric
+        # Ref:
+        # Sra, Suvrit. "A new metric on the manifold of kernel matrices with application to matrix geometric means." Advances in neural information processing systems. 2012.
+        assert not keepdim, "`torch.det` doesn't support keepdim."
+        log_det = lambda x: torch.log(torch.det(x))
+        return log_det((x + y) * 0.5) - 0.5 * log_det(x @ y)
+
+    def _log_eucliden_metric(
+        self, x: torch.Tensor, y: torch.Tensor, keepdim=False
+    ) -> torch.Tensor:
+        # Log-Eucliden Metric
+        # Ref:
+        # Arsigny, Vincent, et al. "Log‐Euclidean metrics for fast and simple calculus on diffusion tensors." Magnetic Resonance in Medicine: An Official Journal of the International Society for Magnetic Resonance in Medicine 56.2 (2006): 411-421.
+        return torch.norm(self._logm(x) - self._logm(y), dim=[-1, -2], keepdim=keepdim)
+
+    def _check_point_on_manifold(
+        self, x: torch.Tensor, *, atol=1e-5, rtol=1e-5
+    ) -> Union[Tuple[bool, Optional[str]], bool]:
+        ok = torch.allclose(x, x.transpose(-1, -2), atol=atol, rtol=rtol)
+        if not ok:
+            return False, "`x != x.transpose` with atol={}, rtol={}".format(atol, rtol)
+        e, _ = torch.symeig(x)
+        ok = (e > -atol).min()
+        if not ok:
+            return False, "eigenvalues of x are not all greater than 0."
+        return True, None
+
+    def _check_vector_on_tangent(
+        self, x: torch.Tensor, u: torch.Tensor, *, atol=1e-5, rtol=1e-5
+    ) -> Union[Tuple[bool, Optional[str]], bool]:
+        ok = torch.allclose(u, u.transpose(-1, -2), atol=atol, rtol=rtol)
+        if not ok:
+            return False, "`u != u.transpose` with atol={}, rtol={}".format(atol, rtol)
+        return True, None
+
+    def projx(self, x: torch.Tensor) -> torch.Tensor:
+        symx = (x + x.transpose(-1, -2)) / 2
+        return self._funcm(symx, partial(torch.clamp, min=EPS[x.dtype]))
+
+    def proju(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
+        return (u + u.transpose(-1, -2)) / 2
+
+    def egrad2rgrad(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
+        return x @ self.proju(x, u) @ x.transpose(-1, -2)
+
+    _dist_metric = {
+        "AIM": _affine_invariant_metric,
+        "SM": _stein_metric,
+        "LEM": _log_eucliden_metric,
+    }
+
+    def dist(
+        self,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        mode: _metric_literal = defaulf_metric,
+        keepdim=False,
+    ) -> torch.Tensor:
+        if mode in self._dist_metric:
+            return self._dist_metric[mode](self, x, y, keepdim=keepdim)
+        else:
+            raise ValueError(
+                "Unsopported metric:'"
+                + mode
+                + "'. Please choose one from "
+                + str(get_args(self._metric_literal))
+            )
+
+    _inner_metric = {
+        "AIM": _affine_invariant_inner,
+    }
+
+    def inner(
+        self,
+        x: torch.Tensor,
+        u: torch.Tensor,
+        v: Optional[torch.Tensor] = None,
+        mode: _metric_literal = defaulf_metric,
+        keepdim=False,
+    ) -> torch.Tensor:
+        if v is None:
+            v = u
+        if mode in self._dist_metric:
+            return self._inner_metric[mode](self, x, u, v, keepdim=keepdim)
+        else:
+            raise ValueError(
+                "Unsopported metric:'"
+                + mode
+                + "'. Please choose one from "
+                + str(get_args(self._metric_literal))
+            )
+
+    def retr(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def expmap(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
+        inv_sqrt_x, sqrt_x = self._inv_sqrtm2(x)
+        return sqrt_x @ self._expm(inv_sqrt_x @ u @ inv_sqrt_x) @ sqrt_x
+
+    def logmap(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
+        inv_sqrt_x, sqrt_x = self._inv_sqrtm2(x)
+        return sqrt_x @ self._logm(inv_sqrt_x @ u @ inv_sqrt_x) @ sqrt_x
+
+    def extra_repr(self):
+        return "ndim={}".format(self.ndim)

--- a/geoopt/manifolds/symmetric_positive_definite.py
+++ b/geoopt/manifolds/symmetric_positive_definite.py
@@ -99,9 +99,10 @@ class SymmetricPositiveDefinite(Manifold):
         def log_det(tensor: torch.Tensor) -> torch.Tensor:
             return torch.log(torch.det(tensor))
 
+        ret = log_det((x + y) * 0.5) - 0.5 * log_det(x @ y)
         if keepdim:
-            raise ValueError("`torch.det` doesn't support keepdim.")
-        return log_det((x + y) * 0.5) - 0.5 * log_det(x @ y)
+            return torch.unsqueeze(torch.unsqueeze(ret, -1), -1)
+        return ret
 
     def _log_eucliden_metric(
         self, x: torch.Tensor, y: torch.Tensor, keepdim=False
@@ -231,10 +232,11 @@ class SymmetricPositiveDefinite(Manifold):
         """
         if v is None:
             v = u
-        if keepdim:
-            raise ValueError("`torch.trace` doesn't support keepdim.")
         inv_x = batch_linalg.sym_invm(x)
-        return torch.trace(inv_x @ u @ inv_x @ v)
+        ret = batch_linalg.trace(inv_x @ u @ inv_x @ v)
+        if keepdim:
+            return torch.unsqueeze(torch.unsqueeze(ret, -1), -1)
+        return ret
 
     def retr(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
         inv_x = batch_linalg.sym_invm(x)

--- a/geoopt/manifolds/symmetric_positive_definite.py
+++ b/geoopt/manifolds/symmetric_positive_definite.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Callable, Literal, Optional, Tuple, Union, get_args
+from typing import Callable, Optional, Tuple, Union, get_args
 import torch
 from .base import Manifold
 
@@ -29,8 +29,8 @@ class SymmetricPositiveDefinite(Manifold):
     Parameters
     ----------
     ndim : int
-        number of trailing dimensions treated as matrix dimensions. 
-        All the operations acting on such as inner products, etc 
+        number of trailing dimensions treated as matrix dimensions.
+        All the operations acting on such as inner products, etc
         will respect the :attr:`ndim`.
     """
 
@@ -38,10 +38,9 @@ class SymmetricPositiveDefinite(Manifold):
     name = "SymmetricPositiveDefinite"
     ndim = 0
     reversible = True
-    _metric_literal = Literal["AIM", "SM", "LEM"]
-    defaulf_metric: _metric_literal = "AIM"
+    defaulf_metric: str = "AIM"
 
-    def __init__(self, ndim=2, defaulf_metric: _metric_literal = defaulf_metric):
+    def __init__(self, ndim=2, defaulf_metric: str = defaulf_metric):
         super().__init__()
         self.ndim = ndim
         self.defaulf_metric = defaulf_metric
@@ -296,7 +295,7 @@ class SymmetricPositiveDefinite(Manifold):
         self,
         x: torch.Tensor,
         y: torch.Tensor,
-        mode: _metric_literal = defaulf_metric,
+        mode: str = defaulf_metric,
         keepdim=False,
     ) -> torch.Tensor:
         """Compute distance between 2 points on the manifold that is the shortest path along geodesics.
@@ -307,7 +306,7 @@ class SymmetricPositiveDefinite(Manifold):
             point on the manifold
         y : torch.Tensor
             point on the manifold
-        mode : _metric_literal, optional
+        mode : str, optional
             choose metric to compute distance, by default defaulf_metric
         keepdim : bool, optional
             keep the last dim?, by default False
@@ -320,7 +319,7 @@ class SymmetricPositiveDefinite(Manifold):
         Raises
         ------
         ValueError
-            if `mode` isn't in `_metric_literal`
+            if `mode` isn't in `_dist_metric`
         """
         if mode in self._dist_metric:
             return self._dist_metric[mode](self, x, y, keepdim=keepdim)
@@ -329,12 +328,8 @@ class SymmetricPositiveDefinite(Manifold):
                 "Unsopported metric:'"
                 + mode
                 + "'. Please choose one from "
-                + str(get_args(self._metric_literal))
+                + str(tuple(self._dist_metric.keys()))
             )
-
-    _inner_metric = {
-        "AIM": _affine_invariant_inner,
-    }
 
     def inner(
         self,
@@ -373,7 +368,6 @@ class SymmetricPositiveDefinite(Manifold):
             raise ValueError("`torch.trace` doesn't support keepdim.")
         inv_x = self._invm(x)
         return torch.trace(inv_x @ u @ inv_x @ v)
-        
 
     def retr(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
         inv_x = self._invm(x)

--- a/geoopt/manifolds/symmetric_positive_definite.py
+++ b/geoopt/manifolds/symmetric_positive_definite.py
@@ -1,4 +1,3 @@
-from functools import partial
 from typing import Optional, Tuple, Union
 import torch
 from .base import Manifold
@@ -255,5 +254,13 @@ class SymmetricPositiveDefinite(Manifold):
 
     def transp(self, x: torch.Tensor, y: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
         inv_sqrt_x, sqrt_x = batch_linalg.sym_inv_sqrtm2(x)
-        exp_x_y = batch_linalg.sym_expm(0.5 * batch_linalg.sym_logm(inv_sqrt_x @ y @ inv_sqrt_x))
-        return  sqrt_x @ exp_x_y  @ batch_linalg.sym(inv_sqrt_x @ v @ inv_sqrt_x)  @ exp_x_y @ sqrt_x
+        exp_x_y = batch_linalg.sym_expm(
+            0.5 * batch_linalg.sym_logm(inv_sqrt_x @ y @ inv_sqrt_x)
+        )
+        return (
+            sqrt_x
+            @ exp_x_y
+            @ batch_linalg.sym(inv_sqrt_x @ v @ inv_sqrt_x)
+            @ exp_x_y
+            @ sqrt_x
+        )

--- a/geoopt/manifolds/symmetric_positive_definite.py
+++ b/geoopt/manifolds/symmetric_positive_definite.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Callable, Optional, Tuple, Union, get_args
+from typing import Callable, Optional, Tuple, Union
 import torch
 from .base import Manifold
 

--- a/geoopt/manifolds/symmetric_positive_definite.py
+++ b/geoopt/manifolds/symmetric_positive_definite.py
@@ -271,3 +271,12 @@ class SymmetricPositiveDefinite(Manifold):
         tens = batch_linalg.sym(tens)
         tens = batch_linalg.sym_funcm(tens, torch.exp)
         return tens
+
+    def origin(
+        self,
+        *size: Union[int, Tuple[int]],
+        dtype=None,
+        device=None,
+        seed: Optional[int] = 42
+    ) -> torch.Tensor:
+        return torch.diag_embed(torch.ones(*size[:-1], dtype=dtype, device=device))

--- a/geoopt/manifolds/symmetric_positive_definite.py
+++ b/geoopt/manifolds/symmetric_positive_definite.py
@@ -78,7 +78,7 @@ class SymmetricPositiveDefinite(Manifold):
         Returns
         -------
         torch.Tensor
-            exp(x)
+            :math:`\exp(x)`
         """
         if using_native:
             return torch.matrix_exp(x)
@@ -86,7 +86,7 @@ class SymmetricPositiveDefinite(Manifold):
             return self._funcm(x, torch.exp)
 
     def _logm(self, x: torch.Tensor) -> torch.Tensor:
-        """Symmetric matrix logarithm.
+        r"""Symmetric matrix logarithm.
 
         Parameters
         ----------
@@ -96,7 +96,7 @@ class SymmetricPositiveDefinite(Manifold):
         Returns
         -------
         torch.Tensor
-            log(x)
+            :math:`\log(x)`
         """
         return self._funcm(x, torch.log)
 
@@ -111,7 +111,7 @@ class SymmetricPositiveDefinite(Manifold):
         Returns
         -------
         torch.Tensor
-            sqrt(x)
+            :math:`x^{1/2}`
         """
         return self._funcm(x, torch.sqrt)
 
@@ -126,7 +126,7 @@ class SymmetricPositiveDefinite(Manifold):
         Returns
         -------
         torch.Tensor
-            x^{-1}
+            :math:`x^{-1}`
         """
         return self._funcm(x, torch.reciprocal)
 
@@ -141,7 +141,7 @@ class SymmetricPositiveDefinite(Manifold):
         Returns
         -------
         torch.Tensor
-            x^{-1/2}
+            :math:`x^{-1/2}`
         """
         return self._funcm(x, lambda tensor: torch.reciprocal(torch.sqrt(tensor)))
 
@@ -156,7 +156,7 @@ class SymmetricPositiveDefinite(Manifold):
         Returns
         -------
         Tuple[torch.Tensor, torch.Tensor]
-            x^{-1/2}, sqrt(x)
+            :math:`x^{-1/2}`, :math:`x^{1/2}`
         """
         e, v = torch.symeig(x, eigenvectors=True)
         sqrt_e = torch.sqrt(e)

--- a/tests/test_manifold_basic.py
+++ b/tests/test_manifold_basic.py
@@ -31,6 +31,7 @@ manifold_shapes = {
     geoopt.manifolds.Sphere: (10,),
     geoopt.manifolds.SphereExact: (10,),
     geoopt.manifolds.ProductManifold: (10 + 3 + 6 + 1,),
+    geoopt.manifolds.SymmetricPositiveDefinite: (2, 2),
 }
 
 
@@ -268,6 +269,22 @@ def sphere_case():
     yield case
 
 
+def spd_case():
+    torch.manual_seed(42)
+    shape = manifold_shapes[geoopt.manifolds.SymmetricPositiveDefinite]
+    ex = torch.randn(*shape, dtype=torch.float64)
+    ev = torch.randn(*shape, dtype=torch.float64)
+    x = geoopt.linalg.batch_linalg.sym_funcm(
+        geoopt.linalg.batch_linalg.sym(ex), torch.abs
+    )
+    v = geoopt.linalg.batch_linalg.sym(ev)
+
+    manifold = geoopt.SymmetricPositiveDefinite(2)
+    x = geoopt.ManifoldTensor(x, manifold=manifold)
+    case = UnaryCase(shape, x, ex, v, ev, manifold)
+    yield case
+
+
 def product_case():
     torch.manual_seed(42)
     ex = [torch.randn(10), torch.randn(3) / 10, torch.randn(3, 2), torch.randn(())]
@@ -338,6 +355,7 @@ def scaled(request):
         sphere_projection_case(),
         product_case(),
         birkhoff_case(),
+        spd_case(),
     ),
     ids=lambda case: case.manifold.__class__.__name__,
 )

--- a/tests/test_rsgd.py
+++ b/tests/test_rsgd.py
@@ -54,8 +54,8 @@ def test_rsgd_spd(params):
     manifold = geoopt.manifolds.SymmetricPositiveDefinite(3)
     torch.manual_seed(42)
     with torch.no_grad():
-        X = geoopt.ManifoldParameter(manifold.random(2,2), manifold=manifold).proj_()
-    Xstar = manifold.random(2,2)
+        X = geoopt.ManifoldParameter(manifold.random(2, 2), manifold=manifold).proj_()
+    Xstar = manifold.random(2, 2)
     # Xstar.set_(manifold.projx(Xstar))
 
     def closure():


### PR DESCRIPTION
I'm trying to implement the SPD manifolds, which is widely used in many papers. 

Current commits have implemented all abstract methods of `base.Manifold`, while more method implementations are on the way.
Some test has been done locally and constructions of the testing module are also on the way.

### Progress
 * [x] move symmetric matrix operations to `batch_linalg`
 * [x] `keepdims` functionality  for `inner` and `_stein_metric`.
 * [x] mention in documentation about SPD manifolds.
 * [x] implementation for `random` and `origin`
 * [x] manifold test module.
    * [x] shape case for a symmetric positive-definite matrix.
    * [x] test basic operation of SPD manifolds.
    * [x] simple optimization problem on SPD manifolds.
 * [ ] mention the PR in the `CHANGELOG`.

### Reference Implementation
 - [`psd.py`](https://github.com/pymanopt/pymanopt/blob/master/pymanopt/manifolds/psd.py) in [pymanopt](https://github.com/pymanopt/pymanopt)
 - [`spd.py`](https://github.com/dalab/matrix-manifolds/blob/master/graphembed/graphembed/manifolds/spd.py) in [matrix-manifolds](https://github.com/dalab/matrix-manifolds)
 - [`psd.py`](https://github.com/Lezcano/geotorch/blob/master/geotorch/psd.py) in [geotorch](https://github.com/Lezcano/geotorch)
 - [`spd_matrices.py`](https://github.com/geomstats/geomstats/blob/master/geomstats/geometry/spd_matrices.py) in [geotorch](https://github.com/geomstats/geomstats) 

### Some paper using SPD Manifolds 
- Computationally Tractable Riemannian Manifolds for Graph Embeddings [[arxiv](https://arxiv.org/abs/2002.08665)]
- A Riemannian Network for SPD Matrix Learning [[arxiv](https://arxiv.org/abs/1608.04233)] 


All suggestions will be accepted with an open mind. Hoping this pull request will be merged when all works have done.