### PR TITLE
Fix valid domain checking of `arcosh()` function

### DIFF
--- a/geoopt/manifolds/lorentz/math.py
+++ b/geoopt/manifolds/lorentz/math.py
@@ -152,7 +152,7 @@ def project(x, *, k, dim=-1):
 
     .. math::
 
-        \Pi_{\mathbb{R}^{d+1} \rightarrow \mathbb{H}^{d, 1}}(\mathbf{x}):=\left(\sqrt{k+\left\|\mathbf{x}_{1: d}\right\|_{2}^{2}}, \mathbf{x}_{1: d}\right)
+        \Pi_{\mathbb{R}^{d+1} \rightarrow \mathbb{H}^{d, 1}}(\mathbf{x}):=\left(\sqrt{k**2+\left\|\mathbf{x}_{1: d}\right\|_{2}^{2}}, \mathbf{x}_{1: d}\right)
 
     Parameters
     ----------
@@ -175,7 +175,7 @@ def project(x, *, k, dim=-1):
 def _project(x, k: torch.Tensor, dim: int = -1):
     dn = x.size(dim) - 1
     left_ = torch.sqrt(
-        k + torch.norm(x.narrow(dim, 1, dn), p=2, dim=dim) ** 2
+        k**2 + torch.norm(x.narrow(dim, 1, dn), p=2, dim=dim) ** 2
     ).unsqueeze(dim)
     right_ = x.narrow(dim, 1, dn)
     proj = torch.cat((left_, right_), dim=dim)

--- a/geoopt/manifolds/lorentz/math.py
+++ b/geoopt/manifolds/lorentz/math.py
@@ -152,7 +152,7 @@ def project(x, *, k, dim=-1):
 
     .. math::
 
-        \Pi_{\mathbb{R}^{d+1} \rightarrow \mathbb{H}^{d, 1}}(\mathbf{x}):=\left(\sqrt{k**2+\left\|\mathbf{x}_{1: d}\right\|_{2}^{2}}, \mathbf{x}_{1: d}\right)
+        \Pi_{\mathbb{R}^{d+1} \rightarrow \mathbb{H}^{d, 1}}(\mathbf{x}):=\left(\sqrt{k+\left\|\mathbf{x}_{1: d}\right\|_{2}^{2}}, \mathbf{x}_{1: d}\right)
 
     Parameters
     ----------
@@ -175,7 +175,7 @@ def project(x, *, k, dim=-1):
 def _project(x, k: torch.Tensor, dim: int = -1):
     dn = x.size(dim) - 1
     left_ = torch.sqrt(
-        k**2 + torch.norm(x.narrow(dim, 1, dn), p=2, dim=dim) ** 2
+        k + torch.norm(x.narrow(dim, 1, dn), p=2, dim=dim) ** 2
     ).unsqueeze(dim)
     right_ = x.narrow(dim, 1, dn)
     proj = torch.cat((left_, right_), dim=dim)

--- a/geoopt/manifolds/lorentz/math.py
+++ b/geoopt/manifolds/lorentz/math.py
@@ -151,7 +151,7 @@ def project(x, *, k, dim=-1):
 
     .. math::
 
-        \Pi_{\mathbb{R}^{d+1} \rightarrow \mathbb{H}^{d, 1}}(\mathbf{x}):=\left(\sqrt{k+\left\|\mathbf{x}_{1: d}\right\|_{2}^{2}}, \mathbf{x}_{1: d}\right)
+        \Pi_{\mathbb{R}^{d+1} \rightarrow \mathbb{H}^{d, 1}}(\mathbf{x}):=\left(\sqrt{k^2+\left\|\mathbf{x}_{1: d}\right\|_{2}^{2}}, \mathbf{x}_{1: d}\right)
 
     Parameters
     ----------
@@ -174,7 +174,7 @@ def project(x, *, k, dim=-1):
 def _project(x, k: torch.Tensor, dim: int = -1):
     dn = x.size(dim) - 1
     left_ = torch.sqrt(
-        k + torch.norm(x.narrow(dim, 1, dn), p=2, dim=dim) ** 2
+        k**2 + torch.norm(x.narrow(dim, 1, dn), p=2, dim=dim) ** 2
     ).unsqueeze(dim)
     right_ = x.narrow(dim, 1, dn)
     proj = torch.cat((left_, right_), dim=dim)


### PR DESCRIPTION
Fix valid domain checking of `arcosh()` function in math.py file of Lorentz manifold.

The `arcosh()` function is mathematically defined over the domain $[1, \infty)$ for some input variable $x$. Thus $x$ is clamped to be able to compute `arcosh()`.

However, the original code enforced the domain of arcosh with `z = torch.clamp_min(x.double().pow(2) - 1.0, 1e-15))`. However, in the next line of code, we compute `torch.log(x+z)`. Thus although the variable `z` was valid, the variable `x` was not and adding them `x+z` would result in a negative value being passed into a $\log$ function. Ultimately, this meant that any $x<0$ would cause a `nan` error instead of being clamped appropriately.

To fix this issue, I redefine `x = torch.clamp_min(x, 1.0).double()` and continue to compute `arcosh()` function as normal. 