### PR TITLE
Update birkhoff_polytope.py

### DIFF
--- a/geoopt/manifolds/birkhoff_polytope.py
+++ b/geoopt/manifolds/birkhoff_polytope.py
@@ -245,7 +245,7 @@ def proj_tangent(x, u):
     lhs = B.transpose(1, 2) @ B
     zeta = torch.linalg.solve(lhs, rhs)
     alpha = torch.cat(
-        [torch.ones(batch_size, 1, 1, dtype=x.dtype, device=x.device), zeta[:, 0 : n - 1]], dim=1
+        [torch.ones(batch_size, 1, 1, device=x.device, dtype=x.dtype), zeta[:, 0 : n - 1]], dim=1
     )
     beta = zeta[:, n - 1 : 2 * n - 1]
     rgrad = mu - (alpha + beta.transpose(-1, -2)) * x

--- a/geoopt/manifolds/birkhoff_polytope.py
+++ b/geoopt/manifolds/birkhoff_polytope.py
@@ -245,7 +245,7 @@ def proj_tangent(x, u):
     lhs = B.transpose(1, 2) @ B
     zeta = torch.linalg.solve(lhs, rhs)
     alpha = torch.cat(
-        [torch.ones(batch_size, 1, 1, dtype=x.dtype), zeta[:, 0 : n - 1]], dim=1
+        [torch.ones(batch_size, 1, 1, dtype=x.dtype, device=x.device), zeta[:, 0 : n - 1]], dim=1
     )
     beta = zeta[:, n - 1 : 2 * n - 1]
     rgrad = mu - (alpha + beta.transpose(-1, -2)) * x


### PR DESCRIPTION
Add the `device=x.device` parameter to `torch.ones`

I encountered an issue while using the `geoopt` library. When running my code on a GPU, I received an error from the `proj_tangent` function in `birkhoff_polytope.py`. The error message was: "Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0".

Upon inspecting the source code, I believe the issue may be due to new tensors being created without specifying a device. In PyTorch, newly created tensors default to the CPU, which can lead to device mismatch errors.

I have made modifications to the code that successfully resolve this issue. I hope my changes can assist other developers who use this library.