### PR TITLE
Add cdist (pairwise distance) for Lorentz, Sphere, and Euclidean manifolds

### DIFF
--- a/geoopt/manifolds/base.py
+++ b/geoopt/manifolds/base.py
@@ -394,12 +394,11 @@ class Manifold(torch.nn.Module, metaclass=abc.ABCMeta):
             distance between two points
         """
         raise NotImplementedError
-    
 
     def cdist(self, x: torch.Tensor, y: torch.Tensor, **kwargs) -> torch.Tensor:
         """
         Compute pairwise distances between two batches of points.
-        
+
         Parameters
         ----------
         x : torch.Tensor
@@ -408,7 +407,7 @@ class Manifold(torch.nn.Module, metaclass=abc.ABCMeta):
             Batch of points, shape (..., B2, D)
         **kwargs : dict
             Additional manifold-specific arguments
-            
+
         Returns
         -------
         torch.Tensor

--- a/geoopt/manifolds/base.py
+++ b/geoopt/manifolds/base.py
@@ -394,6 +394,30 @@ class Manifold(torch.nn.Module, metaclass=abc.ABCMeta):
             distance between two points
         """
         raise NotImplementedError
+    
+
+    def cdist(self, x: torch.Tensor, y: torch.Tensor, **kwargs) -> torch.Tensor:
+        """
+        Compute pairwise distances between two batches of points.
+        
+        Parameters
+        ----------
+        x : torch.Tensor
+            Batch of points, shape (..., B1, D)
+        y : torch.Tensor
+            Batch of points, shape (..., B2, D)
+        **kwargs : dict
+            Additional manifold-specific arguments
+            
+        Returns
+        -------
+        torch.Tensor
+            Pairwise distance matrix, shape (..., B1, B2)
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement pairwise distance computation. "
+            "Please implement cdist() for this manifold."
+        )
 
     @__scaling__(ScalingInfo(2))
     def dist2(self, x: torch.Tensor, y: torch.Tensor, *, keepdim=False) -> torch.Tensor:

--- a/geoopt/manifolds/euclidean.py
+++ b/geoopt/manifolds/euclidean.py
@@ -102,11 +102,11 @@ class Euclidean(Manifold):
         elif self.ndim == 1:
             return torch.einsum("...id,...jd->...ij", u, v)
         else:
-            batch_shape_u = u.shape[:-self.ndim-1]
-            batch_shape_v = v.shape[:-self.ndim-1]
-            B1 = u.shape[-self.ndim-1]
-            B2 = v.shape[-self.ndim-1]
-            manifold_size = u.shape[-self.ndim:]
+            batch_shape_u = u.shape[: -self.ndim - 1]
+            batch_shape_v = v.shape[: -self.ndim - 1]
+            B1 = u.shape[-self.ndim - 1]
+            B2 = v.shape[-self.ndim - 1]
+            manifold_size = u.shape[-self.ndim :]
 
             u_flat = u.reshape(*batch_shape_u, B1, -1)
             v_flat = v.reshape(*batch_shape_v, B2, -1)
@@ -118,8 +118,8 @@ class Euclidean(Manifold):
             diff = x.unsqueeze(-1) - y.unsqueeze(-2)
             return diff.abs()
         elif self.ndim == 1:
-            x_norm_sq = (x ** 2).sum(dim=-1, keepdim=True)  # (..., B1, 1)
-            y_norm_sq = (y ** 2).sum(dim=-1, keepdim=True)  # (..., B2, 1)
+            x_norm_sq = (x**2).sum(dim=-1, keepdim=True)  # (..., B1, 1)
+            y_norm_sq = (y**2).sum(dim=-1, keepdim=True)  # (..., B2, 1)
             xy_inner = self.pairwise_inner(x, y)  # (..., B1, B2)
 
             dist_sq = x_norm_sq + y_norm_sq.transpose(-2, -1) - 2 * xy_inner
@@ -128,17 +128,17 @@ class Euclidean(Manifold):
             return torch.sqrt(dist_sq)
         else:
             # Higher-dimensional case
-            batch_shape_x = x.shape[:-self.ndim-1]
-            batch_shape_y = y.shape[:-self.ndim-1]
-            B1 = x.shape[-self.ndim-1]
-            B2 = y.shape[-self.ndim-1]
+            batch_shape_x = x.shape[: -self.ndim - 1]
+            batch_shape_y = y.shape[: -self.ndim - 1]
+            B1 = x.shape[-self.ndim - 1]
+            B2 = y.shape[-self.ndim - 1]
 
             # Flatten manifold dimensions
             x_flat = x.reshape(*batch_shape_x, B1, -1)
             y_flat = y.reshape(*batch_shape_y, B2, -1)
 
-            x_norm_sq = (x_flat ** 2).sum(dim=-1, keepdim=True)
-            y_norm_sq = (y_flat ** 2).sum(dim=-1, keepdim=True)
+            x_norm_sq = (x_flat**2).sum(dim=-1, keepdim=True)
+            y_norm_sq = (y_flat**2).sum(dim=-1, keepdim=True)
             xy_inner = torch.einsum("...id,...jd->...ij", x_flat, y_flat)
 
             dist_sq = x_norm_sq + y_norm_sq.transpose(-2, -1) - 2 * xy_inner

--- a/geoopt/manifolds/euclidean.py
+++ b/geoopt/manifolds/euclidean.py
@@ -96,6 +96,55 @@ class Euclidean(Manifold):
         else:
             return (x - y).pow(2)
 
+    def pairwise_inner(self, u: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        if self.ndim == 0:
+            return torch.einsum("...i,...j->...ij", u, v)
+        elif self.ndim == 1:
+            return torch.einsum("...id,...jd->...ij", u, v)
+        else:
+            batch_shape_u = u.shape[:-self.ndim-1]
+            batch_shape_v = v.shape[:-self.ndim-1]
+            B1 = u.shape[-self.ndim-1]
+            B2 = v.shape[-self.ndim-1]
+            manifold_size = u.shape[-self.ndim:]
+
+            u_flat = u.reshape(*batch_shape_u, B1, -1)
+            v_flat = v.reshape(*batch_shape_v, B2, -1)
+
+            return torch.einsum("...id,...jd->...ij", u_flat, v_flat)
+
+    def cdist(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        if self.ndim == 0:
+            diff = x.unsqueeze(-1) - y.unsqueeze(-2)
+            return diff.abs()
+        elif self.ndim == 1:
+            x_norm_sq = (x ** 2).sum(dim=-1, keepdim=True)  # (..., B1, 1)
+            y_norm_sq = (y ** 2).sum(dim=-1, keepdim=True)  # (..., B2, 1)
+            xy_inner = self.pairwise_inner(x, y)  # (..., B1, B2)
+
+            dist_sq = x_norm_sq + y_norm_sq.transpose(-2, -1) - 2 * xy_inner
+            # Clamp to avoid numerical issues with sqrt of negative numbers
+            dist_sq = dist_sq.clamp(min=0)
+            return torch.sqrt(dist_sq)
+        else:
+            # Higher-dimensional case
+            batch_shape_x = x.shape[:-self.ndim-1]
+            batch_shape_y = y.shape[:-self.ndim-1]
+            B1 = x.shape[-self.ndim-1]
+            B2 = y.shape[-self.ndim-1]
+
+            # Flatten manifold dimensions
+            x_flat = x.reshape(*batch_shape_x, B1, -1)
+            y_flat = y.reshape(*batch_shape_y, B2, -1)
+
+            x_norm_sq = (x_flat ** 2).sum(dim=-1, keepdim=True)
+            y_norm_sq = (y_flat ** 2).sum(dim=-1, keepdim=True)
+            xy_inner = torch.einsum("...id,...jd->...ij", x_flat, y_flat)
+
+            dist_sq = x_norm_sq + y_norm_sq.transpose(-2, -1) - 2 * xy_inner
+            dist_sq = dist_sq.clamp(min=0)
+            return torch.sqrt(dist_sq)
+
     def egrad2rgrad(self, x: torch.Tensor, u: torch.Tensor) -> torch.Tensor:
         target_shape = broadcast_shapes(x.shape, u.shape)
         return u.expand(target_shape)

--- a/geoopt/manifolds/lorentz/__init__.py
+++ b/geoopt/manifolds/lorentz/__init__.py
@@ -76,6 +76,11 @@ class Lorentz(Manifold):
     def dist0(self, x: torch.Tensor, *, dim=-1, keepdim=False) -> torch.Tensor:
         return math.dist0(x, k=self.k, dim=dim, keepdim=keepdim)
 
+    def cdist(
+        self, X: torch.Tensor, Y: torch.Tensor, *, dim=-1
+    ) -> torch.Tensor:
+        return math.cdist(X, Y, k=self.k, dim=dim)
+
     def norm(self, u: torch.Tensor, *, keepdim=False, dim=-1) -> torch.Tensor:
         return math.norm(u, keepdim=keepdim, dim=dim)
 

--- a/geoopt/manifolds/lorentz/__init__.py
+++ b/geoopt/manifolds/lorentz/__init__.py
@@ -76,10 +76,8 @@ class Lorentz(Manifold):
     def dist0(self, x: torch.Tensor, *, dim=-1, keepdim=False) -> torch.Tensor:
         return math.dist0(x, k=self.k, dim=dim, keepdim=keepdim)
 
-    def cdist(
-        self, X: torch.Tensor, Y: torch.Tensor, *, dim=-1
-    ) -> torch.Tensor:
-        return math.cdist(X, Y, k=self.k, dim=dim)
+    def cdist(self, X: torch.Tensor, Y: torch.Tensor) -> torch.Tensor:
+        return math.cdist(X, Y, k=self.k)
 
     def norm(self, u: torch.Tensor, *, keepdim=False, dim=-1) -> torch.Tensor:
         return math.norm(u, keepdim=keepdim, dim=dim)

--- a/geoopt/manifolds/lorentz/math.py
+++ b/geoopt/manifolds/lorentz/math.py
@@ -79,6 +79,40 @@ def _inner0(v, k: torch.Tensor, keepdim: bool = False, dim: int = -1):
     return res
 
 
+def pairwise_inner(U, V, *, dim=-1):
+    r"""
+    Compute pairwise Minkowski inner products between two batches of vectors.
+
+    Parameters
+    ----------
+    U : tensor
+        Batch of vectors in ambient space, shape (..., B1, D)
+    V : tensor
+        Batch of vectors in ambient space, shape (..., B2, D)
+    dim : int
+        Reduction dimension
+
+    Returns
+    -------
+    tensor
+        Pairwise inner product matrix, shape (..., B1, B2)
+    """
+    return _pairwise_inner(U, V, dim=dim)
+
+
+@torch.jit.script
+def _pairwise_inner(U, V, dim: int = -1):
+    d = U.size(dim) - 1
+    U_time = U.narrow(dim, 0, 1)
+    U_space = U.narrow(dim, 1, d)
+    V_time = V.narrow(dim, 0, 1)
+    V_space = V.narrow(dim, 1, d)
+    time_product = -torch.einsum("...i,...j->...ij", U_time.squeeze(dim), V_time.squeeze(dim))
+    space_product = torch.einsum("...id,...jd->...ij", U_space, V_space)
+
+    return time_product + space_product
+
+
 def dist(x, y, *, k, keepdim=False, dim=-1):
     r"""
     Compute geodesic distance on the Hyperboloid.
@@ -143,6 +177,35 @@ def dist0(x, *, k, keepdim=False, dim=-1):
 def _dist0(x, k: torch.Tensor, keepdim: bool = False, dim: int = -1):
     d = -_inner0(x, k=k, dim=dim, keepdim=keepdim)
     return torch.sqrt(k) * arcosh(d / k)
+
+
+def cdist(X, Y, *, k, dim=-1):
+    r"""
+    Compute pairwise geodesic distances on the Hyperboloid between two batches of points.
+
+    Parameters
+    ----------
+    X : tensor
+        Batch of points on Hyperboloid, shape (..., B1, D)
+    Y : tensor
+        Batch of points on Hyperboloid, shape (..., B2, D)
+    k : tensor
+        manifold negative curvature
+    dim : int
+        reduction dimension
+
+    Returns
+    -------
+    tensor
+        Pairwise geodesic distance matrix, shape (..., B1, B2)
+    """
+    return _cdist(X, Y, k=k, dim=dim)
+
+
+@torch.jit.script
+def _cdist(X, Y, k: torch.Tensor, dim: int = -1):
+    D = -_pairwise_inner(X, Y, dim=dim)
+    return torch.sqrt(k) * arcosh(D / k)
 
 
 def project(x, *, k, dim=-1):

--- a/geoopt/manifolds/lorentz/math.py
+++ b/geoopt/manifolds/lorentz/math.py
@@ -107,7 +107,9 @@ def _pairwise_inner(U, V, dim: int = -1):
     U_space = U.narrow(dim, 1, d)
     V_time = V.narrow(dim, 0, 1)
     V_space = V.narrow(dim, 1, d)
-    time_product = -torch.einsum("...i,...j->...ij", U_time.squeeze(dim), V_time.squeeze(dim))
+    time_product = -torch.einsum(
+        "...i,...j->...ij", U_time.squeeze(dim), V_time.squeeze(dim)
+    )
     space_product = torch.einsum("...id,...jd->...ij", U_space, V_space)
 
     return time_product + space_product
@@ -179,7 +181,7 @@ def _dist0(x, k: torch.Tensor, keepdim: bool = False, dim: int = -1):
     return torch.sqrt(k) * arcosh(d / k)
 
 
-def cdist(X, Y, *, k, dim=-1):
+def cdist(X, Y, *, k):
     r"""
     Compute pairwise geodesic distances on the Hyperboloid between two batches of points.
 
@@ -199,12 +201,12 @@ def cdist(X, Y, *, k, dim=-1):
     tensor
         Pairwise geodesic distance matrix, shape (..., B1, B2)
     """
-    return _cdist(X, Y, k=k, dim=dim)
+    return _cdist(X, Y, k=k)
 
 
 @torch.jit.script
-def _cdist(X, Y, k: torch.Tensor, dim: int = -1):
-    D = -_pairwise_inner(X, Y, dim=dim)
+def _cdist(X, Y, k: torch.Tensor):
+    D = -_pairwise_inner(X, Y, dim=-1)
     return torch.sqrt(k) * arcosh(D / k)
 
 

--- a/geoopt/manifolds/sphere.py
+++ b/geoopt/manifolds/sphere.py
@@ -163,9 +163,7 @@ class Sphere(Manifold):
         return torch.acos(inner)
 
     def cdist(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        inner = self.pairwise_inner(x, y).clamp(
-            -1 + EPS[x.dtype], 1 - EPS[x.dtype]
-        )
+        inner = self.pairwise_inner(x, y).clamp(-1 + EPS[x.dtype], 1 - EPS[x.dtype])
         return torch.acos(inner)
 
     egrad2rgrad = proju

--- a/geoopt/manifolds/sphere.py
+++ b/geoopt/manifolds/sphere.py
@@ -123,6 +123,9 @@ class Sphere(Manifold):
         target_shape = broadcast_shapes(x.shape[:-1] + (1,) * keepdim, inner.shape)
         return inner.expand(target_shape)
 
+    def pairwise_inner(self, u: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        return torch.einsum("...id,...jd->...ij", u, v)
+
     def projx(self, x: torch.Tensor) -> torch.Tensor:
         x = self._project_on_subspace(x)
         return x / x.norm(dim=-1, keepdim=True)
@@ -155,6 +158,12 @@ class Sphere(Manifold):
 
     def dist(self, x: torch.Tensor, y: torch.Tensor, *, keepdim=False) -> torch.Tensor:
         inner = self.inner(x, x, y, keepdim=keepdim).clamp(
+            -1 + EPS[x.dtype], 1 - EPS[x.dtype]
+        )
+        return torch.acos(inner)
+
+    def cdist(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        inner = self.pairwise_inner(x, y).clamp(
             -1 + EPS[x.dtype], 1 - EPS[x.dtype]
         )
         return torch.acos(inner)


### PR DESCRIPTION
### Summary
This PR adds efficient pairwise distance computation (`cdist`) to three manifold types, enabling computing the distance matrix between batches of vectors.

### Motivation
When implementing contrastive learning methods (e.g., CLIP) on manifolds, we need to compute all-pairs distance matrices between two batches of embeddings. Currently, geoopt only provides element-wise `dist()`, requiring slow double loops for pairwise computation.

### Changes

#### Lorentz Manifold
- Added `pairwise_inner()` and `_pairwise_inner()` in `geoopt/manifolds/lorentz/math.py` for pairwise Minkowski inner products
- Added `cdist()` and `_cdist()` for pairwise hyperbolic distances
- Added `cdist()` method to `Lorentz` class in `__init__.py`
- Uses JIT compilation for performance

#### Sphere Manifold  
- Added `pairwise_inner()` for pairwise Euclidean inner products
- Added `cdist()` for pairwise geodesic distances on the sphere
- Includes numerical stability via clamping for arccos

#### Euclidean Manifold
- Added `pairwise_inner()` for pairwise inner products
- Added `cdist()` for pairwise L2 distances
- Supports all ndim values (0, 1, >1)
- Uses efficient ||x-y||² = ||x||² + ||y||² - 2⟨x,y⟩ identity

### Performance
All implementations use vectorized einsum operations

### Testing
Comprehensive test suites verify:
- Correctness vs element-wise dist()
- Mathematical properties (symmetry, triangle inequality)
- Numerical stability
- Gradient flow
- Edge cases

### API Design
- Follows existing geoopt patterns (dim parameter, manifold methods)
- No `keepdim` parameter in `cdist` 
- Returns distance matrix of shape (B1, B2) for inputs (B1, D) and (B2, D)

### Backward Compatibility
All changes are additive - no breaking changes to existing API.
