### PR TITLE
feat: migrate to ruff

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,11 +8,13 @@ on:
     branches: [ master ]
     paths:
       - "**.py"
+      - "pyproject.toml"
       - ".github/workflows/testing.yml"
   pull_request:
     branches: [ master ]
     paths:
       - "**.py"
+      - "pyproject.toml"
       - ".github/workflows/testing.yml"
   schedule:
     - cron: "0 0 * * 0"
@@ -39,7 +41,7 @@ jobs:
         python -m pip install --upgrade pip wheel setuptools
         pip install -e ."[dev]"
         pip install torch==${{ matrix.pytorch-version }}
-        
+
     - name: Run info
       run: |
         which python && python --version && python -c 'import torch; print("torch", torch.__version__)'
@@ -47,7 +49,7 @@ jobs:
       run: make lint
     - name: Run Tests
       run: |
-        pytest -v geoopt tests --durations=0 --doctest-modules --cov geoopt --cov-report=xml --cov-report term 
+        pytest -v geoopt tests --durations=0 --doctest-modules --cov geoopt --cov-report=xml --cov-report term
     - name: Coveralls
       uses: codecov/codecov-action@v4.3.0
       with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dockstyle-check codestyle-check linter-check black test lint check sphinx-check
+.PHONY: help linter-check ruff-check test lint check sphinx-check
 .DEFAULT_GOAL = help
 
 PYTHON = python
@@ -10,34 +10,24 @@ help:
 	@printf "Usage:\n"
 	@grep -E '^[a-zA-Z_-]+:.*?# .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?# "}; {printf "\033[1;34mmake %-15s\033[0m%s\n", $$1, $$2}'
 
-docstyle-check:  # Check geoopt with pydocstyle
-	@printf "Checking documentation with pydocstyle...\n"
-	pydocstyle geoopt --config=pyproject.toml
-	@printf "\033[1;34mPydocstyle passes!\033[0m\n\n"
-
 sphinx-check:
 	@printf "Checking sphinx build...\n"
 	SPHINXOPTS=-W make -C docs -f Makefile clean html
 	@printf "\033[1;34mSphinx passes!\033[0m\n\n"
 
-codestyle-check:  # Check geoopt with black
-	@printf "Checking code style with black...\n"
-	black --check --diff geoopt tests
-	@printf "\033[1;34mBlack passes!\033[0m\n\n"
+linter-check:  # Check geoopt with ruff
+	@printf "Checking code with ruff...\n"
+	ruff check geoopt
+	@printf "\033[1;34mLint checks pass!\033[0m\n\n"
 
-linter-check:  # Check geoopt with pylint
-	@printf "Checking code style with pylint...\n"
-	pylint geoopt
-	@printf "\033[1;34mPylint passes!\033[0m\n\n"
+ruff-check: linter-check  # Run ruff linter checks
 
-black:  # Format code in-place using black.
-	black geoopt tests
+ruff:  # Fix auto-fixable issues with ruff.
+	ruff check --fix geoopt
 
 test:  # Test code using pytest.
 	pytest -v geoopt tests --doctest-modules --html=testing-report.html --self-contained-html
 
-lint: linter-check codestyle-check docstyle-check sphinx-check # Lint code using black, pylint, pydocstyle and sphinx.
+lint: ruff-check sphinx-check  # Lint code using ruff and sphinx.
 
 check: lint test # Both lint and test code. Runs `make lint` followed by `make test`.
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,11 @@ dev = [
     "pytest",
     "pytest-cov",
     "pytest-html",
-    "black",
+    "ruff>=0.4.0",
     "coveralls",
     "twine",
     "wheel",
     "seaborn",
-    "pydocstyle>=6.3.0",
-    "pylint",
     "sphinx"
 ]
 
@@ -53,19 +51,29 @@ rtd = [
     "matplotlib"
 ]
 
-[tool.pydocstyle]
-convention = "numpy"
-add-ignore = [
-    "D100",
-    "D101",
-    "D102",
-    "D103",
-    "D104",
-    "D105",
-    "D106",
-    "D107",
-    "D202"
+[tool.ruff]
+line-length = 100
+target-version = "py38"
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
 ]
+ignore = [
+    "E501",
+    "E721",
+    "E741",
+    "F401",
+    "F811",
+    "F841",
+    "I001",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
 
 [tool.pytest.ini_options]
 filterwarnings = [
@@ -74,292 +82,4 @@ filterwarnings = [
     "default::RuntimeWarning",
 ]
 
-[tool.pylint.main]
-# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
-# number of processors available to use, and will cap the count on Windows to
-# avoid hangs.
-jobs = 1
 
-[tool.pylint.basic]
-
-# Good variable names which should always be accepted, separated by a comma
-good-names = ["i", "j", "k", "ex", "Run", "_"]
-
-# Bad variable names which should always be refused, separated by a comma
-bad-names = ["foo", "bar", "baz", "toto", "tutu", "tata"]
-
-# Colon-delimited sets of names that determine each other's naming style when
-# the name regexes allow several styles.
-# name-group=
-
-# Include a hint for the correct naming format with invalid-name
-include-naming-hint = true
-
-# Regular expression matching correct method names
-method-rgx = "[a-z_][a-z0-9_]{2,30}$"
-
-# Regular expression matching correct function names
-function-rgx = "[a-z_][a-z0-9_]{2,30}$"
-
-# Regular expression matching correct module names
-module-rgx = "(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$"
-
-# Regular expression matching correct attribute names
-attr-rgx = "[a-z_][a-z0-9_]{2,30}$"
-
-# Regular expression matching correct class attribute names
-class-attribute-rgx = "([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$"
-
-# Regular expression matching correct constant names
-const-rgx = "(([A-Z_][A-Z0-9_]*)|(__.*__))$"
-
-# Regular expression matching correct class names
-class-rgx = "[A-Z_][a-zA-Z0-9]+$"
-
-# Regular expression matching correct argument names
-argument-rgx = "[a-z_][a-z0-9_]{2,30}$"
-
-# Regular expression matching correct inline iteration names
-inlinevar-rgx = "[A-Za-z_][A-Za-z0-9_]*$"
-
-# Regular expression matching correct variable names
-variable-rgx = "[a-z_][a-z0-9_]{2,30}$"
-
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx = "^_"
-
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length=-1
-
-[tool.pylint."messages control"]
-# Only show warnings with the listed confidence levels. Leave empty to show all.
-# Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
-# confidence = 
-
-# Disable the message, report, category or checker with the given id(s). You can
-# either give multiple identifiers separated by comma (,) or put this option
-# multiple times (only on the command line, not in the configuration file where
-# it should appear only once). You can also use "--disable=all" to disable
-# everything first and then re-enable specific checks. For example, if you want
-# to run only the similarities checker, you can use "--disable=all
-# --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use "--disable=all --enable=classes
-# --disable=W".
-disable = ["all"]
-
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time. See also the "--disable" option for examples.
-enable = ["import-self",
-       "reimported",
-       "wildcard-import",
-       "misplaced-future",
-       "deprecated-module",
-       "unpacking-non-sequence",
-       "invalid-all-object",
-       "undefined-all-variable",
-       "used-before-assignment",
-       "cell-var-from-loop",
-       "global-variable-undefined",
-       "dangerous-default-value",
-       "unused-import",
-       "unused-wildcard-import",
-       "global-variable-not-assigned",
-       "undefined-loop-variable",
-       "global-statement",
-       "global-at-module-level",
-       "bad-open-mode",
-       "redundant-unittest-assert",
-       "boolean-datetime",
-]
-
-[tool.pylint.reports]
-# Python expression which should return a score less than or equal to 10. You
-# have access to the variables 'fatal', 'error', 'warning', 'refactor',
-# 'convention', and 'info' which contain the number of messages in each category,
-# as well as 'statement' which is the total number of statements analyzed. This
-# score is used by the global evaluation report (RP0004).
-evaluation = "10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)"
-
-# Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio). You can also give a reporter class, e.g.
-# mypackage.mymodule.MyReporterClass.
-output-format = ["parseable"]
-
-# Tells whether to display a full report or only the messages.
-reports = false
-
-[tool.pylint.elif]
-# Maximum number of nested blocks for function / method body
-max-nested-blocks=5
-
-[tool.pylint.format]
-# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-# expected-line-ending-format =
-
-# Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines = "^\\s*(# )?<?https?://\\S+>?$"
-
-# Number of spaces of indent required inside a hanging or continued line.
-indent-after-paren = 4
-
-# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
-# tab).
-indent-string = "    "
-
-# Maximum number of characters on a single line.
-max-line-length = 100
-
-# Maximum number of lines in a module.
-max-module-lines = 1000
-
-# Allow the body of an if to be on the same line as the test if there is no else.
-single-line-if-stmt = false
-
-[tool.pylint.logging]
-# Logging modules to check that the string format arguments are in logging
-# function parameter format.
-logging-modules = ["logging"]
-
-[tool.pylint.miscellaneous]
-# List of note tags to take in consideration, separated by a comma.
-notes = ["FIXME", "XXX", "TODO"]
-
-[tool.pylint.similarities]
-# Comments are removed from the similarity computation
-ignore-comments = true
-
-# Docstrings are removed from the similarity computation
-ignore-docstrings = true
-
-# Imports are removed from the similarity computation
-ignore-imports = false
-
-# Minimum lines number of a similarity.
-min-similarity-lines = 4
-
-[tool.pylint.spelling]
-# Spelling dictionary name. Available dictionaries: none. To make it work,
-# install the 'python-enchant' package.
-# spelling-dict =
-
-# List of comma separated words that should not be checked.
-# spelling-ignore-words =
-
-# A path to a file that contains the private dictionary; one word per line.
-# spelling-private-dict-file =
-
-# Tells whether to store unknown words to the private dictionary (see the
-# --spelling-private-dict-file option) instead of raising a message.
-# spelling-store-unknown-words =
-
-[tool.pylint.typecheck]
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members = true
-
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis. It
-# supports qualified module names, as well as Unix pattern matching.
-# ignored-modules=
-
-# List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamically set). This supports can work
-# with qualified names.
-# ignored-classes=
-
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E1101 when accessed. Python regular
-# expressions are accepted.
-# generated-members =
-
-[tool.pylint.variables]
-# Tells whether we should check for unused import in __init__ files.
-init-import = false
-
-# A regular expression matching the name of dummy variables (i.e. expected to not
-# be used).
-dummy-variables-rgx = "_$|dummy"
-
-# List of additional names supposed to be defined in builtins. Remember that you
-# should avoid defining new builtins when possible.
-# additional-builtins =
-
-# List of strings which can identify a callback function by name. A callback name
-# must start or end with one of those strings.
-callbacks = ["cb_", "_cb"]
-
-[tool.pylint.classes]
-# Warn about protected attribute access inside special methods
-# check-protected-access-in-special-methods =
-
-# List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods = ["__init__", "__new__", "setUp"]
-
-# List of member names, which should be excluded from the protected access
-# warning.
-exclude-protected = ["_asdict", "_fields", "_replace", "_source", "_make"]
-
-# List of valid names for the first argument in a class method.
-valid-classmethod-first-arg = ["cls"]
-
-# List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg = ["mcs"]
-
-[tool.pylint.design]
-# Maximum number of arguments for function / method.
-max-args = 5
-
-# Maximum number of attributes for a class (see R0902).
-max-attributes = 7
-
-# Maximum number of boolean expressions in an if statement (see R0916).
-max-bool-expr = 5
-
-# Maximum number of branch for function / method body.
-max-branches = 12
-
-# Maximum number of locals for function / method body.
-max-locals = 15
-
-# Maximum number of parents for a class (see R0901).
-max-parents = 7
-
-# Maximum number of public methods for a class (see R0904).
-max-public-methods = 20
-
-# Maximum number of return / yield for function / method body.
-max-returns = 6
-
-# Maximum number of statements in function / method body.
-max-statements = 50
-
-# Minimum number of public methods for a class (see R0903).
-min-public-methods = 2
-
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore
-ignored-argument-names="_.*"
-
-[tool.pylint.imports]
-# Deprecated modules which should not be used, separated by a comma.
-deprecated-modules = ["optparse"]
-
-# Output a graph (.gv or any supported image format) of all (i.e. internal and
-# external) dependencies to the given file (report RP0402 must not be disabled).
-# import-graph =
-
-# Output a graph (.gv or any supported image format) of external dependencies to
-# the given file (report RP0402 must not be disabled).
-# ext-import-graph =
-
-# Output a graph (.gv or any supported image format) of internal dependencies to
-# the given file (report RP0402 must not be disabled).
-# int-import-graph =
-
-[tool.pylint.exceptions]
-# Exceptions that will emit a warning when caught.
-overgeneral-exceptions = ["builtins.Exception"]


### PR DESCRIPTION
Migrate to use `ruff` as a linter as opposed to `black`, `pydocstyle` and `pylint`