### PR TITLE
Add lorentz plfc gyrolbn

### DIFF
--- a/geoopt/layers/__init__.py
+++ b/geoopt/layers/__init__.py
@@ -1,1 +1,1 @@
-from .lorentz import LorentzPLFC, PLFC
+from .lorentz import GyroLBN, GyroLorentzBatchNorm, LorentzPLFC, PLFC

--- a/geoopt/layers/__init__.py
+++ b/geoopt/layers/__init__.py
@@ -1,0 +1,1 @@
+from .lorentz import LorentzPLFC, PLFC

--- a/geoopt/layers/lorentz.py
+++ b/geoopt/layers/lorentz.py
@@ -1,0 +1,82 @@
+import torch
+import geoopt
+
+
+class LorentzPLFC(torch.nn.Module):
+    """Point-to-hyperplane fully connected layer on the Lorentz model."""
+
+    def __init__(
+        self,
+        in_features,
+        out_features,
+        *,
+        manifold=None,
+        bias=True,
+        eps=1e-9,
+        init_std=0.02,
+    ):
+        super().__init__()
+        if in_features < 1:
+            raise ValueError("in_features must be positive")
+        if out_features < 1:
+            raise ValueError("out_features must be positive")
+
+        self.in_features = in_features
+        self.out_features = out_features
+        self.manifold = manifold if manifold is not None else geoopt.Lorentz()
+        self.eps = eps
+        self.init_std = init_std
+
+        self.z = torch.nn.Parameter(torch.empty(out_features, in_features))
+        self.a = torch.nn.Parameter(torch.empty(out_features))
+        if bias:
+            self.bias = torch.nn.Parameter(torch.empty(out_features))
+        else:
+            self.register_parameter("bias", None)
+        self.reset_parameters()
+
+    def forward(self, input):
+        distance = self.signed_distance(input)
+        sqrt_k = torch.sqrt(self.manifold.k)
+        space = sqrt_k * torch.sinh(distance / sqrt_k)
+        time = torch.sqrt(self.manifold.k + (space * space).sum(dim=-1, keepdim=True))
+        output = torch.cat((time, space), dim=-1)
+
+        if self.bias is not None:
+            zero = torch.zeros_like(self.bias[..., :1])
+            bias_tangent = torch.cat((zero, self.bias), dim=-1)
+            bias = self.manifold.expmap0(bias_tangent)
+            output = self.manifold.gyroadd(output, bias)
+        return output
+
+    def signed_distance(self, input):
+        r"""Compute signed Lorentz point-to-hyperplane distances."""
+        input_time = input.narrow(-1, 0, 1)
+        input_space = input.narrow(-1, 1, self.in_features)
+        sqrt_k = torch.sqrt(self.manifold.k)
+
+        z_norm = torch.linalg.norm(self.z, dim=-1).clamp_min(self.eps)
+        cosh_term = torch.cosh(self.a / sqrt_k)
+        sinh_term = torch.sinh(self.a / sqrt_k)
+
+        inner = torch.einsum("...i,oi->...o", input_space, self.z)
+        alpha = cosh_term * inner - sinh_term * z_norm * input_time
+        beta = torch.sqrt(((cosh_term * z_norm) ** 2 - (sinh_term * z_norm) ** 2).clamp_min(self.eps))
+        return sqrt_k * beta * torch.asinh(alpha / (sqrt_k * beta))
+
+    def extra_repr(self):
+        return (
+            f"in_features={self.in_features}, "
+            f"out_features={self.out_features}, "
+            f"bias={self.bias is not None}"
+        )
+
+    @torch.no_grad()
+    def reset_parameters(self):
+        torch.nn.init.normal_(self.z, mean=0.0, std=self.init_std)
+        torch.nn.init.zeros_(self.a)
+        if self.bias is not None:
+            torch.nn.init.zeros_(self.bias)
+
+
+PLFC = LorentzPLFC

--- a/geoopt/layers/lorentz.py
+++ b/geoopt/layers/lorentz.py
@@ -51,17 +51,21 @@ class LorentzPLFC(torch.nn.Module):
 
     def signed_distance(self, input):
         r"""Compute signed Lorentz point-to-hyperplane distances."""
+        if input.size(-1) != self.in_features + 1:
+            raise ValueError(
+                f"expected input with last dimension {self.in_features + 1}, "
+                f"got {input.size(-1)}"
+            )
         input_time = input.narrow(-1, 0, 1)
         input_space = input.narrow(-1, 1, self.in_features)
         sqrt_k = torch.sqrt(self.manifold.k)
 
-        z_norm = torch.linalg.norm(self.z, dim=-1).clamp_min(self.eps)
+        beta = torch.linalg.norm(self.z, dim=-1).clamp_min(self.eps)
         cosh_term = torch.cosh(self.a / sqrt_k)
         sinh_term = torch.sinh(self.a / sqrt_k)
 
         inner = torch.einsum("...i,oi->...o", input_space, self.z)
-        alpha = cosh_term * inner - sinh_term * z_norm * input_time
-        beta = torch.sqrt(((cosh_term * z_norm) ** 2 - (sinh_term * z_norm) ** 2).clamp_min(self.eps))
+        alpha = cosh_term * inner - sinh_term * beta * input_time
         return sqrt_k * beta * torch.asinh(alpha / (sqrt_k * beta))
 
     def extra_repr(self):
@@ -113,7 +117,9 @@ class GyroLorentzBatchNorm(torch.nn.Module):
             self.register_parameter("log_scale", None)
 
         if track_running_stats:
-            self.register_buffer("running_mean", self.manifold.origin(num_features + 1).data)
+            self.register_buffer(
+                "running_mean", self.manifold.origin(num_features + 1).detach()
+            )
             self.register_buffer("running_var", torch.ones(()))
         else:
             self.register_buffer("running_mean", None)

--- a/geoopt/layers/lorentz.py
+++ b/geoopt/layers/lorentz.py
@@ -79,4 +79,92 @@ class LorentzPLFC(torch.nn.Module):
             torch.nn.init.zeros_(self.bias)
 
 
+class GyroLorentzBatchNorm(torch.nn.Module):
+    """Gyrogroup batch normalization on the Lorentz model."""
+
+    def __init__(
+        self,
+        num_features,
+        *,
+        manifold=None,
+        eps=1e-5,
+        momentum=0.1,
+        affine=True,
+        track_running_stats=True,
+    ):
+        super().__init__()
+        if num_features < 1:
+            raise ValueError("num_features must be positive")
+
+        self.num_features = num_features
+        self.manifold = manifold if manifold is not None else geoopt.Lorentz()
+        self.eps = eps
+        self.momentum = momentum
+        self.affine = affine
+        self.track_running_stats = track_running_stats
+
+        if affine:
+            self.bias = geoopt.ManifoldParameter(
+                self.manifold.origin(num_features + 1), manifold=self.manifold
+            )
+            self.log_scale = torch.nn.Parameter(torch.zeros(()))
+        else:
+            self.register_parameter("bias", None)
+            self.register_parameter("log_scale", None)
+
+        if track_running_stats:
+            self.register_buffer("running_mean", self.manifold.origin(num_features + 1).data)
+            self.register_buffer("running_var", torch.ones(()))
+        else:
+            self.register_buffer("running_mean", None)
+            self.register_buffer("running_var", None)
+
+    def forward(self, input):
+        if input.size(-1) != self.num_features + 1:
+            raise ValueError(
+                f"expected input with last dimension {self.num_features + 1}, "
+                f"got {input.size(-1)}"
+            )
+
+        if self.training or not self.track_running_stats:
+            mean, var = self._compute_batch_stats(input)
+            if self.training and self.track_running_stats:
+                self._update_running_stats(mean, var)
+        else:
+            mean = self.running_mean
+            var = self.running_var
+
+        centered = self.manifold.gyroadd(self.manifold.gyroinv(mean), input)
+        factor = torch.rsqrt(var + self.eps)
+        if self.affine:
+            factor = self.log_scale.exp() * factor
+        output = self.manifold.gyroscalar(factor, centered)
+        if self.affine:
+            output = self.manifold.gyroadd(self.bias, output)
+        return output
+
+    def _compute_batch_stats(self, input):
+        reducedim = list(range(input.dim() - 1))
+        mean = self.manifold.lorentz_centroid(input, reducedim=reducedim)
+        var = self.manifold.lorentz_dispersion(input, mean, reducedim=reducedim)
+        return mean, var
+
+    @torch.no_grad()
+    def _update_running_stats(self, mean, var):
+        direction = self.manifold.logmap(self.running_mean, mean)
+        new_mean = self.manifold.expmap(self.running_mean, self.momentum * direction)
+        self.running_mean.copy_(new_mean)
+        self.running_var.mul_(1 - self.momentum).add_(self.momentum * var.detach())
+
+    def extra_repr(self):
+        return (
+            f"num_features={self.num_features}, "
+            f"eps={self.eps}, "
+            f"momentum={self.momentum}, "
+            f"affine={self.affine}, "
+            f"track_running_stats={self.track_running_stats}"
+        )
+
+
 PLFC = LorentzPLFC
+GyroLBN = GyroLorentzBatchNorm

--- a/geoopt/manifolds/lorentz/__init__.py
+++ b/geoopt/manifolds/lorentz/__init__.py
@@ -158,6 +158,51 @@ class Lorentz(Manifold):
     def transp0back(self, x: torch.Tensor, u: torch.Tensor, *, dim=-1) -> torch.Tensor:
         return math.parallel_transport0back(x, u, k=self.k, dim=dim)
 
+    def gyroadd(self, x: torch.Tensor, y: torch.Tensor, *, dim=-1) -> torch.Tensor:
+        return math.gyroadd(x, y, k=self.k, dim=dim)
+
+    def gyroinv(self, x: torch.Tensor, *, dim=-1) -> torch.Tensor:
+        return math.gyroinv(x, dim=dim)
+
+    def gyroscalar(self, r: torch.Tensor, x: torch.Tensor, *, dim=-1) -> torch.Tensor:
+        return math.gyroscalar(r, x, k=self.k, dim=dim)
+
+    def lorentz_centroid(
+        self,
+        x: torch.Tensor,
+        weights: torch.Tensor = None,
+        *,
+        reducedim=None,
+        dim=-1,
+        keepdim=False,
+    ) -> torch.Tensor:
+        return math.lorentz_centroid(
+            x,
+            weights=weights,
+            k=self.k,
+            reducedim=reducedim,
+            dim=dim,
+            keepdim=keepdim,
+        )
+
+    def lorentz_dispersion(
+        self,
+        x: torch.Tensor,
+        mean: torch.Tensor,
+        *,
+        reducedim=None,
+        dim=-1,
+        keepdim=False,
+    ) -> torch.Tensor:
+        return math.lorentz_dispersion(
+            x,
+            mean,
+            k=self.k,
+            reducedim=reducedim,
+            dim=dim,
+            keepdim=keepdim,
+        )
+
     def transp_follow_expmap(
         self, x: torch.Tensor, u: torch.Tensor, v: torch.Tensor, *, dim=-1, project=True
     ) -> torch.Tensor:

--- a/geoopt/manifolds/lorentz/math.py
+++ b/geoopt/manifolds/lorentz/math.py
@@ -1,4 +1,8 @@
+from typing import List, Optional
+
 import torch.jit
+
+from ...utils import drop_dims
 
 
 @torch.jit.script
@@ -658,6 +662,256 @@ def _parallel_transport0back(x, v, k, dim: int = -1):
     denom = _dist0(x, k=k, dim=dim, keepdim=True) ** 2
     p = v - nom / denom * (lmap + _logmap0(x, k=k, dim=dim))
     return p
+
+
+def gyroadd(x, y, *, k, dim=-1):
+    r"""
+    Compute gyroaddition on the Lorentz model.
+
+    Parameters
+    ----------
+    x : tensor
+        point on Hyperboloid
+    y : tensor
+        point on Hyperboloid
+    k : tensor
+        manifold negative curvature
+    dim : int
+        reduction dimension for operations
+
+    Returns
+    -------
+    tensor
+        gyroaddition of :math:`x` and :math:`y`
+    """
+    return _gyroadd(x, y, k=k, dim=dim)
+
+
+@torch.jit.script
+def _gyroadd(x, y, k: torch.Tensor, dim: int = -1):
+    d = x.size(dim) - 1
+    x_t = x.narrow(dim, 0, 1)
+    y_t = y.narrow(dim, 0, 1)
+    x_s = x.narrow(dim, 1, d)
+    y_s = y.narrow(dim, 1, d)
+
+    sqrt_k = torch.sqrt(k)
+    inv_k = 1.0 / k
+
+    a = 1.0 + x_t / sqrt_k
+    b = 1.0 + y_t / sqrt_k
+
+    norm_x = (x_s * x_s).sum(dim=dim, keepdim=True)
+    norm_y = (y_s * y_s).sum(dim=dim, keepdim=True)
+    inner_xy = (x_s * y_s).sum(dim=dim, keepdim=True)
+
+    d_term = (
+        a * a * b * b
+        + 2.0 * inv_k * a * b * inner_xy
+        + inv_k * inv_k * norm_x * norm_y
+    )
+    n_term = a * a * norm_y + 2.0 * a * b * inner_xy + b * b * norm_x
+
+    denom = d_term - inv_k * n_term
+    sign = torch.sign(denom)
+    sign = torch.where(sign == 0, torch.ones_like(sign), sign)
+    denom = denom + sign * 1e-15
+
+    time = sqrt_k * (d_term + inv_k * n_term) / denom
+
+    coef_x = a * b * b + 2.0 * inv_k * b * inner_xy + inv_k * a * norm_y
+    coef_y = b * (a * a - inv_k * norm_x)
+    space = 2.0 * (coef_x * x_s + coef_y * y_s) / denom
+    return _project(torch.cat((time, space), dim=dim), k=k, dim=dim)
+
+
+def gyroinv(x, *, k=None, dim=-1):
+    r"""
+    Compute the gyroinverse of a Lorentz point.
+
+    Parameters
+    ----------
+    x : tensor
+        point on Hyperboloid
+    dim : int
+        manifold dimension
+
+    Returns
+    -------
+    tensor
+        gyroinverse of :math:`x`
+    """
+    return _gyroinv(x, dim=dim)
+
+
+@torch.jit.script
+def _gyroinv(x, dim: int = -1):
+    d = x.size(dim) - 1
+    return torch.cat((x.narrow(dim, 0, 1), -x.narrow(dim, 1, d)), dim=dim)
+
+
+def gyroscalar(r, x, *, k, dim=-1):
+    r"""
+    Compute gyro-scalar multiplication on the Lorentz model.
+
+    Parameters
+    ----------
+    r : tensor
+        scalar multiplier
+    x : tensor
+        point on Hyperboloid
+    k : tensor
+        manifold negative curvature
+    dim : int
+        manifold dimension
+
+    Returns
+    -------
+    tensor
+        gyro-scalar multiplication of :math:`x` by :math:`r`
+    """
+    if not torch.is_tensor(r):
+        r = torch.as_tensor(r, dtype=x.dtype, device=x.device)
+    if r.dim() == x.dim() - 1:
+        r = r.unsqueeze(dim)
+    return _gyroscalar(r, x, k=k, dim=dim)
+
+
+@torch.jit.script
+def _gyroscalar(r, x, k: torch.Tensor, dim: int = -1):
+    d = x.size(dim) - 1
+    x_t = x.narrow(dim, 0, 1)
+    x_s = x.narrow(dim, 1, d)
+
+    sqrt_k = torch.sqrt(k)
+    norm_s = torch.norm(x_s, p=2, dim=dim, keepdim=True).clamp_min(1e-15)
+    theta = arcosh((x_t / sqrt_k).clamp_min(1.0))
+    rtheta = r * theta
+
+    time = sqrt_k * torch.cosh(rtheta)
+    space = sqrt_k * torch.sinh(rtheta) * x_s / norm_s
+    return _project(torch.cat((time, space), dim=dim), k=k, dim=dim)
+
+
+def lorentz_centroid(
+    x,
+    weights: Optional[torch.Tensor] = None,
+    *,
+    k,
+    reducedim: Optional[List[int]] = None,
+    dim=-1,
+    keepdim=False,
+    eps=1e-8,
+):
+    r"""
+    Compute the weighted Lorentz centroid.
+
+    Parameters
+    ----------
+    x : tensor
+        points on Hyperboloid
+    weights : tensor
+        optional non-negative weights, broadcastable to ``x`` without the
+        manifold dimension
+    k : tensor
+        manifold negative curvature
+    reducedim : list[int]
+        dimensions to reduce. By default all non-manifold dimensions are reduced
+    dim : int
+        manifold dimension
+    keepdim : bool
+        retain reduced dimensions
+    eps : float
+        numerical stability constant
+
+    Returns
+    -------
+    tensor
+        Lorentz centroid
+    """
+    reducedim = _default_reducedim(x, reducedim, dim)
+    avg = _weighted_average(x, weights, reducedim, dim)
+    denom = torch.sqrt(torch.clamp_min(-_inner(avg, avg, keepdim=True, dim=dim), eps))
+    centroid = torch.sqrt(k) * avg / denom
+    centroid = _project(centroid, k=k, dim=dim)
+    if not keepdim:
+        centroid = drop_dims(centroid, reducedim)
+    return centroid
+
+
+def lorentz_dispersion(
+    x,
+    mean,
+    *,
+    k,
+    reducedim: Optional[List[int]] = None,
+    dim=-1,
+    keepdim=False,
+):
+    r"""
+    Compute mean squared tangent dispersion around a Lorentz mean.
+
+    Parameters
+    ----------
+    x : tensor
+        points on Hyperboloid
+    mean : tensor
+        centroid point on Hyperboloid
+    k : tensor
+        manifold negative curvature
+    reducedim : list[int]
+        dimensions to reduce. By default all non-manifold dimensions are reduced
+    dim : int
+        manifold dimension
+    keepdim : bool
+        retain reduced dimensions
+
+    Returns
+    -------
+    tensor
+        mean squared Lorentz tangent norm
+    """
+    reducedim = _default_reducedim(x, reducedim, dim)
+    u = _logmap(mean, x, k=k, dim=dim)
+    sqnorm = _inner(u, u, keepdim=False, dim=dim).clamp_min(0.0)
+    reducedim = _reducedim_without_manifold(reducedim, x.dim(), dim)
+    if len(reducedim) > 0:
+        sqnorm = sqnorm.mean(dim=reducedim, keepdim=keepdim)
+    return sqnorm
+
+
+def _default_reducedim(x, reducedim: Optional[List[int]], dim: int):
+    ndim = x.dim()
+    dim = dim % ndim
+    if reducedim is None:
+        reducedim = [d for d in range(ndim) if d != dim]
+    else:
+        reducedim = sorted(d % ndim for d in reducedim if d % ndim != dim)
+    return reducedim
+
+
+def _reducedim_without_manifold(reducedim: List[int], ndim: int, dim: int):
+    dim = dim % ndim
+    result = []
+    for d in reducedim:
+        if d < dim:
+            result.append(d)
+        elif d > dim:
+            result.append(d - 1)
+    return result
+
+
+def _weighted_average(x, weights, reducedim: List[int], dim: int):
+    if len(reducedim) == 0:
+        return x
+    if weights is None or weights.dim() == 0:
+        return x.mean(dim=reducedim, keepdim=True)
+    dim = dim % x.dim()
+    if weights.dim() == x.dim() - 1:
+        weights = weights.unsqueeze(dim)
+    weights = torch.broadcast_to(weights, x.shape)
+    denom = weights.sum(dim=reducedim, keepdim=True).clamp_min(1e-15)
+    return (x * weights).sum(dim=reducedim, keepdim=True) / denom
 
 
 def geodesic_unit(t, x, u, *, k):

--- a/geoopt/manifolds/lorentz/math.py
+++ b/geoopt/manifolds/lorentz/math.py
@@ -250,6 +250,12 @@ def _project(x, k: torch.Tensor, dim: int = -1):
     return proj
 
 
+@torch.jit.script
+def _project_space(x, k: torch.Tensor, dim: int = -1):
+    left_ = torch.sqrt(k + torch.norm(x, p=2, dim=dim, keepdim=True) ** 2)
+    return torch.cat((left_, x), dim=dim)
+
+
 def project_polar(x, *, k, dim=-1):
     r"""
     Projection on the Hyperboloid from polar coordinates.
@@ -695,8 +701,8 @@ def _gyroadd(x, y, k: torch.Tensor, dim: int = -1):
     x_s = x.narrow(dim, 1, d)
     y_s = y.narrow(dim, 1, d)
 
-    sqrt_k = torch.sqrt(k)
     inv_k = 1.0 / k
+    sqrt_k = torch.sqrt(k)
 
     a = 1.0 + x_t / sqrt_k
     b = 1.0 + y_t / sqrt_k
@@ -717,15 +723,13 @@ def _gyroadd(x, y, k: torch.Tensor, dim: int = -1):
     sign = torch.where(sign == 0, torch.ones_like(sign), sign)
     denom = denom + sign * 1e-15
 
-    time = sqrt_k * (d_term + inv_k * n_term) / denom
-
     coef_x = a * b * b + 2.0 * inv_k * b * inner_xy + inv_k * a * norm_y
     coef_y = b * (a * a - inv_k * norm_x)
     space = 2.0 * (coef_x * x_s + coef_y * y_s) / denom
-    return _project(torch.cat((time, space), dim=dim), k=k, dim=dim)
+    return _project_space(space, k=k, dim=dim)
 
 
-def gyroinv(x, *, k=None, dim=-1):
+def gyroinv(x, *, dim=-1):
     r"""
     Compute the gyroinverse of a Lorentz point.
 

--- a/tests/test_layers_lorentz.py
+++ b/tests/test_layers_lorentz.py
@@ -62,3 +62,83 @@ def test_lorentz_plfc_backward():
     assert torch.isfinite(layer.z.grad).all()
     assert torch.isfinite(layer.a.grad).all()
     assert torch.isfinite(layer.bias.grad).all()
+
+
+def test_gyro_lorentz_batch_norm_shape_and_manifold():
+    dtype = torch.float64
+    manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
+    layer = geoopt.layers.GyroLorentzBatchNorm(3, manifold=manifold).to(dtype)
+    input = manifold.random_normal(8, 3 + 1).data
+
+    output = layer(input)
+
+    assert output.shape == input.shape
+    assert torch.isfinite(output).all()
+    assert_lorentz_point(manifold, output, atol=1e-6, rtol=1e-6)
+
+
+def test_gyro_lorentz_batch_norm_eval_uses_running_stats():
+    dtype = torch.float64
+    manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
+    layer = geoopt.layers.GyroLorentzBatchNorm(3, manifold=manifold).to(dtype)
+    input = manifold.random_normal(8, 3 + 1).data
+
+    layer.train()
+    layer(input)
+    running_mean = layer.running_mean.clone()
+    running_var = layer.running_var.clone()
+
+    layer.eval()
+    output = layer(manifold.random_normal(8, 3 + 1).data)
+
+    torch.testing.assert_close(layer.running_mean, running_mean)
+    torch.testing.assert_close(layer.running_var, running_var)
+    assert torch.isfinite(output).all()
+    assert_lorentz_point(manifold, output, atol=1e-6, rtol=1e-6)
+
+
+def test_gyro_lorentz_batch_norm_without_affine_or_running_stats():
+    dtype = torch.float64
+    manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
+    layer = geoopt.layers.GyroLorentzBatchNorm(
+        3,
+        manifold=manifold,
+        affine=False,
+        track_running_stats=False,
+    ).to(dtype)
+    input = manifold.random_normal(8, 3 + 1).data
+
+    output = layer(input)
+
+    assert layer.bias is None
+    assert layer.log_scale is None
+    assert layer.running_mean is None
+    assert layer.running_var is None
+    assert torch.isfinite(output).all()
+    assert_lorentz_point(manifold, output, atol=1e-6, rtol=1e-6)
+
+
+def test_gyro_lorentz_batch_norm_small_variance():
+    dtype = torch.float64
+    manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
+    layer = geoopt.layers.GyroLorentzBatchNorm(3, manifold=manifold).to(dtype)
+    input = manifold.origin(3 + 1, dtype=dtype).data.expand(8, 3 + 1).clone()
+
+    output = layer(input)
+
+    assert torch.isfinite(output).all()
+    assert_lorentz_point(manifold, output, atol=1e-6, rtol=1e-6)
+
+
+def test_gyro_lorentz_batch_norm_backward():
+    dtype = torch.float64
+    manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
+    layer = geoopt.layers.GyroLorentzBatchNorm(3, manifold=manifold).to(dtype)
+    input = manifold.random_normal(8, 3 + 1).data.detach().requires_grad_()
+
+    output = layer(input)
+    output.sum().backward()
+
+    assert torch.isfinite(input.grad).all()
+    assert torch.isfinite(layer.bias.grad).all()
+    assert torch.isfinite(layer.log_scale.grad).all()

--- a/tests/test_layers_lorentz.py
+++ b/tests/test_layers_lorentz.py
@@ -1,4 +1,5 @@
 import torch
+import pytest
 
 import geoopt
 import geoopt.layers
@@ -13,7 +14,7 @@ def test_lorentz_plfc_shape_and_manifold():
     dtype = torch.float64
     manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
     layer = geoopt.layers.LorentzPLFC(3, 2, manifold=manifold).to(dtype)
-    input = manifold.random_normal(4, 3 + 1).data
+    input = manifold.random_normal(4, 3 + 1).detach()
 
     output = layer(input)
 
@@ -26,7 +27,7 @@ def test_lorentz_plfc_batch_dims():
     dtype = torch.float64
     manifold = geoopt.Lorentz(k=torch.tensor(2.0, dtype=dtype))
     layer = geoopt.layers.LorentzPLFC(4, 3, manifold=manifold, bias=False).to(dtype)
-    input = manifold.random_normal(2, 5, 4 + 1).data
+    input = manifold.random_normal(2, 5, 4 + 1).detach()
 
     output = layer(input)
 
@@ -39,7 +40,7 @@ def test_lorentz_plfc_signed_distance_matches_output_space():
     dtype = torch.float64
     manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
     layer = geoopt.layers.LorentzPLFC(3, 2, manifold=manifold, bias=False).to(dtype)
-    input = manifold.random_normal(4, 3 + 1).data
+    input = manifold.random_normal(4, 3 + 1).detach()
 
     distance = layer.signed_distance(input)
     output = layer(input)
@@ -49,11 +50,23 @@ def test_lorentz_plfc_signed_distance_matches_output_space():
     assert_lorentz_point(manifold, output, atol=1e-6, rtol=1e-6)
 
 
+def test_lorentz_plfc_rejects_wrong_input_shape():
+    dtype = torch.float64
+    manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
+    layer = geoopt.layers.LorentzPLFC(3, 2, manifold=manifold).to(dtype)
+    input = manifold.random_normal(4, 3 + 2).detach()
+
+    with pytest.raises(ValueError, match="last dimension"):
+        layer(input)
+    with pytest.raises(ValueError, match="last dimension"):
+        layer.signed_distance(input)
+
+
 def test_lorentz_plfc_backward():
     dtype = torch.float64
     manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
     layer = geoopt.layers.LorentzPLFC(3, 2, manifold=manifold).to(dtype)
-    input = manifold.random_normal(4, 3 + 1).data.detach().requires_grad_()
+    input = manifold.random_normal(4, 3 + 1).detach().requires_grad_()
 
     output = layer(input)
     output.sum().backward()
@@ -68,7 +81,7 @@ def test_gyro_lorentz_batch_norm_shape_and_manifold():
     dtype = torch.float64
     manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
     layer = geoopt.layers.GyroLorentzBatchNorm(3, manifold=manifold).to(dtype)
-    input = manifold.random_normal(8, 3 + 1).data
+    input = manifold.random_normal(8, 3 + 1).detach()
 
     output = layer(input)
 
@@ -81,7 +94,7 @@ def test_gyro_lorentz_batch_norm_eval_uses_running_stats():
     dtype = torch.float64
     manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
     layer = geoopt.layers.GyroLorentzBatchNorm(3, manifold=manifold).to(dtype)
-    input = manifold.random_normal(8, 3 + 1).data
+    input = manifold.random_normal(8, 3 + 1).detach()
 
     layer.train()
     layer(input)
@@ -89,7 +102,7 @@ def test_gyro_lorentz_batch_norm_eval_uses_running_stats():
     running_var = layer.running_var.clone()
 
     layer.eval()
-    output = layer(manifold.random_normal(8, 3 + 1).data)
+    output = layer(manifold.random_normal(8, 3 + 1).detach())
 
     torch.testing.assert_close(layer.running_mean, running_mean)
     torch.testing.assert_close(layer.running_var, running_var)
@@ -106,7 +119,7 @@ def test_gyro_lorentz_batch_norm_without_affine_or_running_stats():
         affine=False,
         track_running_stats=False,
     ).to(dtype)
-    input = manifold.random_normal(8, 3 + 1).data
+    input = manifold.random_normal(8, 3 + 1).detach()
 
     output = layer(input)
 
@@ -122,7 +135,7 @@ def test_gyro_lorentz_batch_norm_small_variance():
     dtype = torch.float64
     manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
     layer = geoopt.layers.GyroLorentzBatchNorm(3, manifold=manifold).to(dtype)
-    input = manifold.origin(3 + 1, dtype=dtype).data.expand(8, 3 + 1).clone()
+    input = manifold.origin(3 + 1, dtype=dtype).detach().expand(8, 3 + 1).clone()
 
     output = layer(input)
 
@@ -134,7 +147,7 @@ def test_gyro_lorentz_batch_norm_backward():
     dtype = torch.float64
     manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
     layer = geoopt.layers.GyroLorentzBatchNorm(3, manifold=manifold).to(dtype)
-    input = manifold.random_normal(8, 3 + 1).data.detach().requires_grad_()
+    input = manifold.random_normal(8, 3 + 1).detach().requires_grad_()
 
     output = layer(input)
     output.sum().backward()

--- a/tests/test_layers_lorentz.py
+++ b/tests/test_layers_lorentz.py
@@ -1,0 +1,64 @@
+import torch
+
+import geoopt
+import geoopt.layers
+
+
+def assert_lorentz_point(manifold, point, *, atol=1e-5, rtol=1e-5):
+    ok, reason = manifold._check_point_on_manifold(point, atol=atol, rtol=rtol)
+    assert ok, reason
+
+
+def test_lorentz_plfc_shape_and_manifold():
+    dtype = torch.float64
+    manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
+    layer = geoopt.layers.LorentzPLFC(3, 2, manifold=manifold).to(dtype)
+    input = manifold.random_normal(4, 3 + 1).data
+
+    output = layer(input)
+
+    assert output.shape == (4, 2 + 1)
+    assert torch.isfinite(output).all()
+    assert_lorentz_point(manifold, output, atol=1e-6, rtol=1e-6)
+
+
+def test_lorentz_plfc_batch_dims():
+    dtype = torch.float64
+    manifold = geoopt.Lorentz(k=torch.tensor(2.0, dtype=dtype))
+    layer = geoopt.layers.LorentzPLFC(4, 3, manifold=manifold, bias=False).to(dtype)
+    input = manifold.random_normal(2, 5, 4 + 1).data
+
+    output = layer(input)
+
+    assert output.shape == (2, 5, 3 + 1)
+    assert torch.isfinite(output).all()
+    assert_lorentz_point(manifold, output, atol=1e-6, rtol=1e-6)
+
+
+def test_lorentz_plfc_signed_distance_matches_output_space():
+    dtype = torch.float64
+    manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
+    layer = geoopt.layers.LorentzPLFC(3, 2, manifold=manifold, bias=False).to(dtype)
+    input = manifold.random_normal(4, 3 + 1).data
+
+    distance = layer.signed_distance(input)
+    output = layer(input)
+    expected_space = torch.sqrt(manifold.k) * torch.sinh(distance / torch.sqrt(manifold.k))
+
+    torch.testing.assert_close(output[..., 1:], expected_space)
+    assert_lorentz_point(manifold, output, atol=1e-6, rtol=1e-6)
+
+
+def test_lorentz_plfc_backward():
+    dtype = torch.float64
+    manifold = geoopt.Lorentz(k=torch.tensor(1.0, dtype=dtype))
+    layer = geoopt.layers.LorentzPLFC(3, 2, manifold=manifold).to(dtype)
+    input = manifold.random_normal(4, 3 + 1).data.detach().requires_grad_()
+
+    output = layer(input)
+    output.sum().backward()
+
+    assert torch.isfinite(input.grad).all()
+    assert torch.isfinite(layer.z.grad).all()
+    assert torch.isfinite(layer.a.grad).all()
+    assert torch.isfinite(layer.bias.grad).all()

--- a/tests/test_lorentz_math.py
+++ b/tests/test_lorentz_math.py
@@ -62,14 +62,14 @@ def test_lorentz_poincare(a, k):
 
 def test_randn_mean(k):
     man = lorentz.Lorentz(k=k)
-    a = man.random_normal((10, 500), mean=0).data
+    a = man.random_normal((10, 500), mean=0).detach()
     a = man.logmap0(a).mean(dim=-1)
     np.testing.assert_allclose(a, torch.zeros_like(a), atol=1e-1, rtol=1e-1)
 
 
 def test_origin(k):
     man = lorentz.Lorentz(k=k)
-    a = man.origin(10, 10).data
+    a = man.origin(10, 10).detach()
     b = man.projx(torch.zeros(10, 10))
     np.testing.assert_allclose(a, b, atol=1e-5, rtol=1e-5)
 
@@ -210,7 +210,7 @@ def test_zero_point_ops(a, k):
 def test_lorentz_gyroadd_identity_inverse(a, k):
     man = lorentz.Lorentz(k=k)
     a = man.projx(a)
-    zero = man.origin(a.shape[-1], dtype=a.dtype, device=a.device).data
+    zero = man.origin(a.shape[-1], dtype=a.dtype, device=a.device).detach()
 
     left = man.gyroadd(zero, a)
     right = man.gyroadd(a, zero)
@@ -227,7 +227,7 @@ def test_lorentz_gyroadd_identity_inverse(a, k):
 def test_lorentz_gyroscalar_special_cases(a, k):
     man = lorentz.Lorentz(k=k)
     a = man.projx(a)
-    zero = man.origin(a.shape[-1], dtype=a.dtype, device=a.device).data
+    zero = man.origin(a.shape[-1], dtype=a.dtype, device=a.device).detach()
 
     zero_scaled = man.gyroscalar(torch.zeros((), dtype=a.dtype, device=a.device), a)
     one_scaled = man.gyroscalar(torch.ones((), dtype=a.dtype, device=a.device), a)

--- a/tests/test_lorentz_math.py
+++ b/tests/test_lorentz_math.py
@@ -207,6 +207,55 @@ def test_zero_point_ops(a, k):
     np.testing.assert_allclose(lmap, lmap_z, atol=1e-5, rtol=1e-5)
 
 
+def test_lorentz_gyroadd_identity_inverse(a, k):
+    man = lorentz.Lorentz(k=k)
+    a = man.projx(a)
+    zero = man.origin(a.shape[-1], dtype=a.dtype, device=a.device).data
+
+    left = man.gyroadd(zero, a)
+    right = man.gyroadd(a, zero)
+    inv = man.gyroadd(man.gyroinv(a), a)
+
+    np.testing.assert_allclose(left, a, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(right, a, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(inv, zero.expand_as(inv), atol=1e-5, rtol=1e-5)
+    assert man._check_point_on_manifold(left)[0]
+    assert man._check_point_on_manifold(right)[0]
+    assert man._check_point_on_manifold(inv)[0]
+
+
+def test_lorentz_gyroscalar_special_cases(a, k):
+    man = lorentz.Lorentz(k=k)
+    a = man.projx(a)
+    zero = man.origin(a.shape[-1], dtype=a.dtype, device=a.device).data
+
+    zero_scaled = man.gyroscalar(torch.zeros((), dtype=a.dtype, device=a.device), a)
+    one_scaled = man.gyroscalar(torch.ones((), dtype=a.dtype, device=a.device), a)
+
+    np.testing.assert_allclose(zero_scaled, zero.expand_as(zero_scaled), atol=1e-5)
+    np.testing.assert_allclose(one_scaled, a, atol=1e-5, rtol=1e-5)
+    assert man._check_point_on_manifold(zero_scaled)[0]
+    assert man._check_point_on_manifold(one_scaled)[0]
+
+
+def test_lorentz_centroid_and_dispersion(a, k):
+    man = lorentz.Lorentz(k=k)
+    a = man.projx(a.detach()).requires_grad_()
+    weights = torch.rand(a.shape[0], dtype=a.dtype, device=a.device)
+
+    centroid = man.lorentz_centroid(a, weights=weights, reducedim=[0])
+    dispersion = man.lorentz_dispersion(a, centroid, reducedim=[0])
+
+    assert centroid.shape == a.shape[-1:]
+    assert dispersion.shape == torch.Size([])
+    assert torch.isfinite(centroid).all()
+    assert torch.isfinite(dispersion).all()
+    assert man._check_point_on_manifold(centroid)[0]
+
+    (centroid.sum() + dispersion).backward()
+    assert torch.isfinite(a.grad).all()
+
+
 def test_parallel_transport_a_b(a, b, k):
     man = lorentz.Lorentz(k=k)
     v_0 = torch.rand_like(a)


### PR DESCRIPTION
  Hi Geoopt maintainers,

  I would like to contribute several generic Lorentz-model components derived from our ICLR 2026 paper,
  "Intrinsic Lorentz Neural Network" (ILNN) https://arxiv.org/abs/2602.23981.

  The goal of this PR is not to add the full ILNN model or any experiment-specific training code. Instead,
  I extracted the reusable Lorentz geometry primitives and neural layers that fit Geoopt's scope as
  manifold-aware PyTorch tooling.

  This PR is organized into three reviewable commits:

  1. Add Lorentz gyro primitives

  This commit extends `geoopt.manifolds.lorentz` with Lorentz-native gyro operations and normalization
  helpers:

  - `gyroadd`
  - `gyroinv`
  - `gyroscalar`
  - `lorentz_centroid`
  - `lorentz_dispersion`

  It also adds thin wrapper methods to `geoopt.Lorentz`, following the existing Geoopt style where
  manifold methods delegate to `geoopt.manifolds.lorentz.math`.

  These primitives are useful beyond ILNN, especially for Lorentz-model neural layers and gyrogroup-based
  normalization.

  2. Add Lorentz point-to-hyperplane layer

  This commit adds an experimental Lorentz point-to-hyperplane fully connected layer:

  - `geoopt.layers.LorentzPLFC`
  - alias: `geoopt.layers.PLFC`

  The layer maps Lorentz inputs of shape `(..., in_features + 1)` to Lorentz outputs of shape `(...,
  out_features + 1)`. It uses Geoopt's existing Lorentz curvature convention, where `Lorentz(k)` satisfies
  `<x, x>_L = -k`.

  The implementation is intentionally library-level: it does not include ILNN-specific global state,
  training logic, dataset code, dropout choices, or experiment-specific clamps.

  3. Add GyroLorentz batch normalization

  This commit adds an experimental gyrogroup batch normalization layer:

  - `geoopt.layers.GyroLorentzBatchNorm`
  - alias: `geoopt.layers.GyroLBN`

  The layer uses Lorentz centroid and dispersion statistics, supports running statistics, optional affine
  parameters, and keeps outputs on the Lorentz manifold.

  The implementation is designed as a reusable Lorentz normalization layer rather than a paper-specific
  module.

  Testing:

  I added tests for the new Lorentz primitives and layers, including:

  - Lorentz manifold constraint checks
  - gyro identity/inverse/scalar special cases
  - centroid and dispersion finite-gradient checks
  - PLFC shape, batch-dimension, signed-distance, and backward checks
  - GyroLBN train/eval behavior, running stats, affine=False, small-variance stability, and backward
  checks

  Local verification:

  ```bash
  python -m pytest -q tests/test_lorentz_math.py tests/test_layers_lorentz.py
  # 329 passed

  ruff check geoopt tests
  # All checks passed
  ```

  I also ran the full test suite with PyTorch's legacy torch.load behavior enabled:
  ```bash
  TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 python -m pytest -q tests
  # 9118 passed, 326 skipped
  ```

  Without that environment variable, two existing pickle tests fail due to PyTorch's newer default
  torch.load(weights_only=True), which appears unrelated to this PR.

  I would be happy to adjust naming, API shape, or scope if you prefer keeping only the lower-level
  Lorentz primitives in Geoopt.

